### PR TITLE
refactor(QelNumberInput): 使用枚举类型进行大小和控制位置设置

### DIFF
--- a/QelNumberInput/QelNumberInput.cpp
+++ b/QelNumberInput/QelNumberInput.cpp
@@ -1,0 +1,242 @@
+#include "QelNumberInput.h"
+
+#include <QEvent>
+#include <QHBoxLayout>
+#include <QPainter>
+#include <QStyleOption>
+#include <limits>
+
+namespace qel {
+
+QelNumberInput::QelNumberInput(QWidget *parent,
+                               int minValue,
+                               int maxValue,
+                               double initialValue,
+                               double step,
+                               bool readonly,
+                               bool disabled,
+                               bool controls,
+                               const QString &placeholder)
+    : QWidget(parent),
+    minValue(minValue),
+    maxValue(maxValue),
+    currentValue(initialValue),
+    step(step),
+    readonly(readonly),
+    disabled(disabled),
+    controls(controls),
+    size(Default),
+    precision(0)
+{
+    // 创建按钮和显示框
+    decreaseButton = new QPushButton("-", this);
+    increaseButton = new QPushButton("+", this);
+    valueDisplay = new QLineEdit(QString::number(initialValue, 'f', precision), this);
+
+            // 设置默认按钮大小为正方形，并根据 size 设置整体大小
+    setSize(size);
+
+            // 设置 QLineEdit
+    valueDisplay->setReadOnly(readonly);
+    valueDisplay->setAlignment(Qt::AlignCenter);
+    valueDisplay->setPlaceholderText(placeholder);
+
+            // 设置按钮和输入框的大小策略
+    decreaseButton->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+    increaseButton->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+    valueDisplay->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+
+            // 设置样式表，添加圆角，并设置焦点和 hover 样式
+    QString decreaseButtonStyle = "QPushButton { border: 1px solid #dcdfe6; background-color: #f5f7fa; "
+        "border-top-left-radius: 4px; border-bottom-left-radius: 6px; }"
+        "QPushButton:pressed { background-color: #e6e9ef; }"
+        "QPushButton:hover { border-color: #409EFF; color: #409EFF; }";
+    QString increaseButtonStyle = "QPushButton { border: 1px solid #dcdfe6; background-color: #f5f7fa; "
+        "border-top-right-radius: 4px; border-bottom-right-radius: 6px; }"
+        "QPushButton:pressed { background-color: #e6e9ef; }"
+        "QPushButton:hover { border-color: #409EFF; color: #409EFF; }";
+    decreaseButton->setStyleSheet(decreaseButtonStyle);
+    increaseButton->setStyleSheet(increaseButtonStyle);
+
+    valueDisplay->setStyleSheet("QLineEdit { border-top: 1px solid #dcdfe6; border-bottom: 1px solid #dcdfe6; "
+        "border-left: 0px; border-right: 0px; background-color: white; }");
+
+            // 设置布局
+    QHBoxLayout *layout = new QHBoxLayout(this);
+    layout->setSpacing(0);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->addWidget(decreaseButton);
+    layout->addWidget(valueDisplay);
+    layout->addWidget(increaseButton);
+    setLayout(layout);
+
+            // 连接信号槽
+    connect(decreaseButton, &QPushButton::clicked, this, &QelNumberInput::onDecrease);
+    connect(increaseButton, &QPushButton::clicked, this, &QelNumberInput::onIncrease);
+
+            // 初始状态更新
+    setDisabled(disabled);
+    updateControlsState();
+}
+
+bool QelNumberInput::eventFilter(QObject *obj, QEvent *event) {
+    if (event->type() == QEvent::FocusIn) {
+        setStyleSheet("QWidget { border: 1px solid #409EFF; }");
+        qDebug() << "Focus In Event Triggered";
+        return true;
+    } else if (event->type() == QEvent::FocusOut) {
+        setStyleSheet("QWidget { border: 1px solid #dcdfe6; }");
+        qDebug() << "Focus Out Event Triggered";
+        return true;
+    }
+    return QWidget::eventFilter(obj, event);
+}
+
+void QelNumberInput::setSize(Size size) {
+    this->size = size;
+    int buttonSize;
+    int widgetHeight;
+    int widgetWidth;
+    int fontSize;
+
+    switch (size) {
+    case Small:
+        buttonSize = 26;
+        widgetHeight = buttonSize;
+        widgetWidth = buttonSize * 5;
+        fontSize = 14;
+        break;
+    case Default:
+        buttonSize = 38;
+        widgetHeight = buttonSize;
+        widgetWidth = buttonSize * 5;
+        fontSize = 16;
+        break;
+    case Large:
+        buttonSize = 42;
+        widgetHeight = buttonSize;
+        widgetWidth = buttonSize * 5;
+        fontSize = 18;
+        break;
+    }
+
+            // 设置加减按钮为正方形，并调整整体大小
+    decreaseButton->setFixedSize(buttonSize, buttonSize);
+    increaseButton->setFixedSize(buttonSize, buttonSize);
+    valueDisplay->setFixedHeight(buttonSize);
+    valueDisplay->setFixedWidth(buttonSize*3);
+
+            // 设置按钮的字体大小
+    QFont font = decreaseButton->font();
+    font.setPointSize(fontSize);
+    decreaseButton->setFont(font);
+    increaseButton->setFont(font);
+
+    setFixedSize(widgetWidth, widgetHeight);  // 设置整个控件的大小
+}
+
+void QelNumberInput::onFocusIn() {
+    setStyleSheet("QWidget { border: 1px solid #409EFF; }");
+    qDebug() << "onFocusIn";
+}
+
+void QelNumberInput::onFocusOut() {
+    setStyleSheet("QWidget { border: 1px solid #dcdfe6; }");
+}
+
+void QelNumberInput::focusInEvent(QFocusEvent *event) {
+    QWidget::focusInEvent(event);
+    setStyleSheet("QWidget { border: 1px solid #409EFF; }");
+    qDebug() << "onFocusIn";
+}
+
+void QelNumberInput::focusOutEvent(QFocusEvent *event) {
+    QWidget::focusOutEvent(event);
+    setStyleSheet("QWidget { border: 1px solid #dcdfe6; }");
+}
+
+void QelNumberInput::paintEvent(QPaintEvent *event) {
+    QStyleOption opt;
+    opt.initFrom(this);  // 从当前 widget 初始化 opt
+
+    QPainter p(this);
+    style()->drawPrimitive(QStyle::PE_Widget, &opt, &p, this);
+}
+
+double QelNumberInput::value() const {
+    return currentValue;
+}
+
+void QelNumberInput::setValue(double value) {
+    if (value >= minValue && value <= maxValue) {
+        currentValue = value;
+        updateDisplay();
+        emit valueChanged(currentValue);
+    }
+}
+
+void QelNumberInput::setMinValue(int minValue) {
+    this->minValue = minValue;
+}
+
+void QelNumberInput::setMaxValue(int maxValue) {
+    this->maxValue = maxValue;
+}
+
+void QelNumberInput::setStep(double step) {
+    this->step = step;
+}
+
+void QelNumberInput::setReadonly(bool readonly) {
+    this->readonly = readonly;
+    valueDisplay->setReadOnly(readonly);
+}
+
+void QelNumberInput::setDisabled(bool disabled) {
+    this->disabled = disabled;
+    setEnabled(!disabled);
+    updateControlsState();
+}
+
+void QelNumberInput::setPlaceholder(const QString &placeholder) {
+    valueDisplay->setPlaceholderText(placeholder);
+}
+
+void QelNumberInput::setPrecision(int precision) {
+    this->precision = precision;
+    updateDisplay();
+}
+
+void QelNumberInput::onIncrease() {
+    if (currentValue + step <= maxValue) {
+        currentValue += step;
+        updateDisplay();
+        emit valueChanged(currentValue);
+        emit increaseIconClicked();
+    }
+}
+
+void QelNumberInput::onDecrease() {
+    if (currentValue - step >= minValue) {
+        currentValue -= step;
+        updateDisplay();
+        emit valueChanged(currentValue);
+        emit decreaseIconClicked();
+    }
+}
+
+void QelNumberInput::updateDisplay() {
+    valueDisplay->setText(QString::number(currentValue, 'f', precision));
+}
+
+void QelNumberInput::updateControlsState() {
+    decreaseButton->setVisible(controls);
+    increaseButton->setVisible(controls);
+    if (!controls) {
+        valueDisplay->setFixedWidth(size == Large ? 5 * 42 : size == Default ? 5 * 38 : 5 * 26); // 修改宽度以适应无控制按钮状态
+    }
+    decreaseButton->setEnabled(!disabled && controls);
+    increaseButton->setEnabled(!disabled && controls);
+}
+
+}

--- a/QelNumberInput/QelNumberInput.h
+++ b/QelNumberInput/QelNumberInput.h
@@ -1,9 +1,9 @@
 #ifndef QELNUMBERINPUT_H
 #define QELNUMBERINPUT_H
 
+#include <QWidget>
 #include <QLineEdit>
 #include <QPushButton>
-#include <QWidget>
 
 namespace qel {
 
@@ -11,66 +11,57 @@ class QelNumberInput : public QWidget {
     Q_OBJECT
 
 public:
-    enum Size {
-        Small,
-        Default,
-        Large
-    };
+    enum class Size { Small, Default, Large };
+    enum class ControlsPosition { Default, Right };  // 添加 ControlsPosition 枚举
 
     explicit QelNumberInput(QWidget *parent = nullptr,
-                            int minValue = -std::numeric_limits<int>::max(),
-                            int maxValue = std::numeric_limits<int>::max(),
+                            int minValue = 0,
+                            int maxValue = 100,
                             double initialValue = 0,
                             double step = 1,
                             bool readonly = false,
                             bool disabled = false,
                             bool controls = true,
+                            ControlsPosition controlsPosition = ControlsPosition::Default,  // 使用枚举类型
                             const QString &placeholder = "");
+
+    void setSize(Size size);
+    void setPrecision(int precision);
+    void setControlsPosition(ControlsPosition position);  // 添加 setControlsPosition 函数
 
     double value() const;
     void setValue(double value);
+
     void setMinValue(int minValue);
     void setMaxValue(int maxValue);
     void setStep(double step);
     void setReadonly(bool readonly);
     void setDisabled(bool disabled);
     void setPlaceholder(const QString &placeholder);
-    void setSize(Size size);
-    void setPrecision(int precision);
-
-protected:
-    void focusInEvent(QFocusEvent *event) override;    // 声明 focusInEvent
-    void focusOutEvent(QFocusEvent *event) override;   // 声明 focusOutEvent
-    void paintEvent(QPaintEvent *event) override;      // 声明 paintEvent
-    bool eventFilter(QObject *obj, QEvent *event) override;
 
 signals:
-    void valueChanged(double newValue);
-    void decreaseIconClicked();
+    void valueChanged(double value);
     void increaseIconClicked();
-
-private slots:
-    void onIncrease();
-    void onDecrease();
-    void onFocusIn();
-    void onFocusOut();
+    void decreaseIconClicked();
 
 private:
-    QPushButton *decreaseButton;
-    QPushButton *increaseButton;
-    QLineEdit *valueDisplay;
-    QWidget *container;
-
     int minValue;
     int maxValue;
-    double step;
     double currentValue;
+    double step;
     bool readonly;
     bool disabled;
     bool controls;
     Size size;
     int precision;
+    ControlsPosition controlsPosition;  // 使用枚举类型
 
+    QPushButton *decreaseButton;
+    QPushButton *increaseButton;
+    QLineEdit *valueDisplay;
+
+    void onIncrease();
+    void onDecrease();
     void updateDisplay();
     void updateControlsState();
 };

--- a/QelNumberInput/QelNumberInput.h
+++ b/QelNumberInput/QelNumberInput.h
@@ -1,0 +1,80 @@
+#ifndef QELNUMBERINPUT_H
+#define QELNUMBERINPUT_H
+
+#include <QLineEdit>
+#include <QPushButton>
+#include <QWidget>
+
+namespace qel {
+
+class QelNumberInput : public QWidget {
+    Q_OBJECT
+
+public:
+    enum Size {
+        Small,
+        Default,
+        Large
+    };
+
+    explicit QelNumberInput(QWidget *parent = nullptr,
+                            int minValue = -std::numeric_limits<int>::max(),
+                            int maxValue = std::numeric_limits<int>::max(),
+                            double initialValue = 0,
+                            double step = 1,
+                            bool readonly = false,
+                            bool disabled = false,
+                            bool controls = true,
+                            const QString &placeholder = "");
+
+    double value() const;
+    void setValue(double value);
+    void setMinValue(int minValue);
+    void setMaxValue(int maxValue);
+    void setStep(double step);
+    void setReadonly(bool readonly);
+    void setDisabled(bool disabled);
+    void setPlaceholder(const QString &placeholder);
+    void setSize(Size size);
+    void setPrecision(int precision);
+
+protected:
+    void focusInEvent(QFocusEvent *event) override;    // 声明 focusInEvent
+    void focusOutEvent(QFocusEvent *event) override;   // 声明 focusOutEvent
+    void paintEvent(QPaintEvent *event) override;      // 声明 paintEvent
+    bool eventFilter(QObject *obj, QEvent *event) override;
+
+signals:
+    void valueChanged(double newValue);
+    void decreaseIconClicked();
+    void increaseIconClicked();
+
+private slots:
+    void onIncrease();
+    void onDecrease();
+    void onFocusIn();
+    void onFocusOut();
+
+private:
+    QPushButton *decreaseButton;
+    QPushButton *increaseButton;
+    QLineEdit *valueDisplay;
+    QWidget *container;
+
+    int minValue;
+    int maxValue;
+    double step;
+    double currentValue;
+    bool readonly;
+    bool disabled;
+    bool controls;
+    Size size;
+    int precision;
+
+    void updateDisplay();
+    void updateControlsState();
+};
+
+}
+
+#endif // QELNUMBERINPUT_H

--- a/QelNumberInput/QelNumberInput.pro
+++ b/QelNumberInput/QelNumberInput.pro
@@ -1,0 +1,24 @@
+QT       += core gui
+
+greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
+
+CONFIG += c++17
+
+# You can make your code fail to compile if it uses deprecated APIs.
+# In order to do so, uncomment the following line.
+#DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
+
+SOURCES += \
+    main.cpp \
+    QelNumberInput.cpp
+
+HEADERS += \
+    QelNumberInput.h \
+    QelNumberInputTester.h
+
+# Default rules for deployment.
+qnx: target.path = /tmp/$${TARGET}/bin
+else: unix:!android: target.path = /opt/$${TARGET}/bin
+!isEmpty(target.path): INSTALLS += target
+
+include($$PWD/../QelIcon/QelIcon.pri))

--- a/QelNumberInput/QelNumberInputTester.h
+++ b/QelNumberInput/QelNumberInputTester.h
@@ -1,0 +1,138 @@
+#ifndef QELNUMBERINPUTTESTER_H
+#define QELNUMBERINPUTTESTER_H
+
+#include "QelNumberInput.h"
+#include <QWidget>
+#include <QVBoxLayout>
+#include <QLabel>
+
+using qel::QelNumberInput;
+
+class QelNumberInputTester : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit QelNumberInputTester(QWidget *parent = nullptr) : QWidget(parent) {
+        QVBoxLayout *mainLayout = new QVBoxLayout(this);
+
+        // 基础用法
+        mainLayout->addWidget(createNumberInput("基础用法", 0, 100, 5, 1, false, false, true));
+
+        // 禁用状态
+        mainLayout->addWidget(createNumberInput("禁用状态", 0, 10, 1, 1, false, true, true));
+
+        // 严格步进
+        mainLayout->addWidget(createNumberInput("严格步进", 0, 100, 18, 10, true, false, true));
+
+        // 精度
+        mainLayout->addWidget(createNumberInput("精度", 0, 100, 1.5, 0.1, false, false, true, 2));
+
+        // 不同尺寸
+        mainLayout->addWidget(createSizedNumberInput("不同尺寸"));
+
+        // 不同尺寸，没有控制按钮、
+        mainLayout->addWidget(createSizedNoControlNumberInput("不同尺寸&无控制按钮"));
+
+        // 按钮位置
+        mainLayout->addWidget(createControlsPositionNumberInput("按钮位置"));
+
+        setLayout(mainLayout);
+    }
+
+private:
+    QWidget* createNumberInput(const QString &labelText, int minValue, int maxValue, double initialValue, double step,
+                               bool stepStrictly = false, bool disabled = false, bool controls = true, int precision = 0) {
+        QWidget *widget = new QWidget(this);
+        QVBoxLayout *layout = new QVBoxLayout(widget);
+
+        QLabel *label = new QLabel(labelText, widget);
+        QelNumberInput *numberInput = new QelNumberInput(widget, minValue, maxValue, initialValue, step);
+        numberInput->setReadonly(false);
+        numberInput->setDisabled(disabled);
+        numberInput->setPrecision(precision);
+
+        layout->addWidget(label);
+        layout->addWidget(numberInput);
+        layout->setSpacing(10);
+        layout->setContentsMargins(20, 20, 20, 20);
+
+        return widget;
+    }
+
+    QWidget* createSizedNumberInput(const QString &labelText) {
+        QWidget *widget = new QWidget(this);
+        QVBoxLayout *layout = new QVBoxLayout(widget);
+
+        QLabel *label = new QLabel(labelText, widget);
+        QHBoxLayout *sizesLayout = new QHBoxLayout();
+
+        QelNumberInput *smallInput = new QelNumberInput(widget, 0, 10, 1, 1);
+        smallInput->setSize(QelNumberInput::Small);
+
+        QelNumberInput *defaultInput = new QelNumberInput(widget, 0, 10, 2, 1);
+        defaultInput->setSize(QelNumberInput::Default);
+
+        QelNumberInput *largeInput = new QelNumberInput(widget, 0, 10, 3, 1);
+        largeInput->setSize(QelNumberInput::Large);
+
+        sizesLayout->addWidget(smallInput);
+        sizesLayout->addWidget(defaultInput);
+        sizesLayout->addWidget(largeInput);
+
+        layout->addWidget(label);
+        layout->addLayout(sizesLayout);
+
+        return widget;
+    }
+
+    QWidget* createControlsPositionNumberInput(const QString &labelText) {
+        QWidget *widget = new QWidget(this);
+        QVBoxLayout *layout = new QVBoxLayout(widget);
+
+        QLabel *label = new QLabel(labelText, widget);
+        QHBoxLayout *controlsLayout = new QHBoxLayout();
+
+//        QelNumberInput *leftInput = new QelNumberInput(widget, 0, 10, 1, 1);
+//        leftInput->setControlsPosition(QelNumberInput::ControlsPosition::Left);
+
+//        QelNumberInput *rightInput = new QelNumberInput(widget, 0, 10, 1, 1);
+//        rightInput->setControlsPosition(QelNumberInput::ControlsPosition::Right);
+
+//        controlsLayout->addWidget(leftInput);
+//        controlsLayout->addWidget(rightInput);
+
+        layout->addWidget(label);
+        layout->addLayout(controlsLayout);
+
+        return widget;
+    }
+
+    QWidget* createSizedNoControlNumberInput(const QString &labelText) {
+        QWidget *widget = new QWidget(this);
+        QVBoxLayout *layout = new QVBoxLayout(widget);
+
+        QLabel *label = new QLabel(labelText, widget);
+        QHBoxLayout *sizesLayout = new QHBoxLayout();
+
+        QelNumberInput *smallInput = new QelNumberInput(widget, 0, 10, 1, 1, false, false, false);
+        smallInput->setSize(QelNumberInput::Small);
+
+        QelNumberInput *defaultInput = new QelNumberInput(widget, 0, 10, 2, 1, false, false, false);
+        defaultInput->setSize(QelNumberInput::Default);
+
+        QelNumberInput *largeInput = new QelNumberInput(widget, 0, 10, 3, 1, false, false, false);
+        largeInput->setSize(QelNumberInput::Large);
+
+        sizesLayout->addWidget(smallInput);
+        sizesLayout->addWidget(defaultInput);
+        sizesLayout->addWidget(largeInput);
+
+        layout->addWidget(label);
+        layout->addLayout(sizesLayout);
+
+        return widget;
+    }
+
+};
+
+#endif // QELNUMBERINPUTTESTER_H

--- a/QelNumberInput/QelNumberInputTester.h
+++ b/QelNumberInput/QelNumberInputTester.h
@@ -67,13 +67,13 @@ private:
         QHBoxLayout *sizesLayout = new QHBoxLayout();
 
         QelNumberInput *smallInput = new QelNumberInput(widget, 0, 10, 1, 1);
-        smallInput->setSize(QelNumberInput::Small);
+        smallInput->setSize(QelNumberInput::Size::Small);
 
         QelNumberInput *defaultInput = new QelNumberInput(widget, 0, 10, 2, 1);
-        defaultInput->setSize(QelNumberInput::Default);
+        defaultInput->setSize(QelNumberInput::Size::Default);
 
         QelNumberInput *largeInput = new QelNumberInput(widget, 0, 10, 3, 1);
-        largeInput->setSize(QelNumberInput::Large);
+        largeInput->setSize(QelNumberInput::Size::Large);
 
         sizesLayout->addWidget(smallInput);
         sizesLayout->addWidget(defaultInput);
@@ -92,14 +92,14 @@ private:
         QLabel *label = new QLabel(labelText, widget);
         QHBoxLayout *controlsLayout = new QHBoxLayout();
 
-//        QelNumberInput *leftInput = new QelNumberInput(widget, 0, 10, 1, 1);
-//        leftInput->setControlsPosition(QelNumberInput::ControlsPosition::Left);
+        QelNumberInput *leftInput = new QelNumberInput(widget, 0, 10, 1, 1);
+        leftInput->setControlsPosition(QelNumberInput::ControlsPosition::Default);
 
-//        QelNumberInput *rightInput = new QelNumberInput(widget, 0, 10, 1, 1);
-//        rightInput->setControlsPosition(QelNumberInput::ControlsPosition::Right);
+        QelNumberInput *rightInput = new QelNumberInput(widget, 0, 10, 1, 1);
+        rightInput->setControlsPosition(QelNumberInput::ControlsPosition::Right);
 
-//        controlsLayout->addWidget(leftInput);
-//        controlsLayout->addWidget(rightInput);
+        controlsLayout->addWidget(leftInput);
+        controlsLayout->addWidget(rightInput);
 
         layout->addWidget(label);
         layout->addLayout(controlsLayout);
@@ -115,13 +115,13 @@ private:
         QHBoxLayout *sizesLayout = new QHBoxLayout();
 
         QelNumberInput *smallInput = new QelNumberInput(widget, 0, 10, 1, 1, false, false, false);
-        smallInput->setSize(QelNumberInput::Small);
+        smallInput->setSize(QelNumberInput::Size::Small);
 
         QelNumberInput *defaultInput = new QelNumberInput(widget, 0, 10, 2, 1, false, false, false);
-        defaultInput->setSize(QelNumberInput::Default);
+        defaultInput->setSize(QelNumberInput::Size::Default);
 
         QelNumberInput *largeInput = new QelNumberInput(widget, 0, 10, 3, 1, false, false, false);
-        largeInput->setSize(QelNumberInput::Large);
+        largeInput->setSize(QelNumberInput::Size::Large);
 
         sizesLayout->addWidget(smallInput);
         sizesLayout->addWidget(defaultInput);

--- a/QelNumberInput/main.cpp
+++ b/QelNumberInput/main.cpp
@@ -1,0 +1,15 @@
+#include <QApplication>
+#include <QMainWindow>
+#include "QelNumberInputTester.h"
+
+int main(int argc, char *argv[]) {
+    QApplication app(argc, argv);
+
+    QMainWindow mainWindow;
+    QelNumberInputTester *tester = new QelNumberInputTester();
+    mainWindow.setCentralWidget(tester);
+    mainWindow.resize(800, 600);
+    mainWindow.show();
+
+    return app.exec();
+}


### PR DESCRIPTION
重构`QelNumberInput`类，使用枚举类型`Size`和`ControlsPosition`来定义输入控件的大小和控制按钮的位置。
`Size`枚举现为`Size::Small`、`Size::Default`和`Size::Large`，而`ControlsPosition`枚举包含`ControlsPosition::Default`和`ControlsPosition::Right`。
此外，`setControlsPosition`方法已添加，用于根据`controlsPosition`参数设置控制按钮的位置。

BREAKING CHANGE: `Size`和`ControlsPosition`枚举类型的定义已更改，方法签名也已更新以使用这些枚举类型。
请确保在使用这些方法时使用新的枚举值。