### PR TITLE
Add_numberinputer_show

### DIFF
--- a/QelNumberInput/QelNumberInput.pri
+++ b/QelNumberInput/QelNumberInput.pri
@@ -1,0 +1,5 @@
+SOURCES += \
+        $$PWD/QelNumberInput.cpp
+
+HEADERS += \
+        $$PWD/QelNumberInput.h

--- a/QelNumberInput/QelNumberInput.pro
+++ b/QelNumberInput/QelNumberInput.pro
@@ -21,4 +21,5 @@ qnx: target.path = /tmp/$${TARGET}/bin
 else: unix:!android: target.path = /opt/$${TARGET}/bin
 !isEmpty(target.path): INSTALLS += target
 
-include($$PWD/../QelIcon/QelIcon.pri))
+DISTFILES += \
+    QelNumberInput.pri

--- a/QelNumberInput/QelNumberInputTester.h
+++ b/QelNumberInput/QelNumberInputTester.h
@@ -9,8 +9,6 @@
 using qel::QelNumberInput;
 
 class QelNumberInputTester : public QWidget {
-    Q_OBJECT
-
 public:
     explicit QelNumberInputTester(QWidget *parent = nullptr) : QWidget(parent) {
         QVBoxLayout *mainLayout = new QVBoxLayout(this);

--- a/QelShow/QelShow.pro
+++ b/QelShow/QelShow.pro
@@ -41,3 +41,4 @@ else: unix:!android: target.path = /opt/$${TARGET}/bin
 
 include($$PWD/../QelButton/QelButton.pri))
 include($$PWD/../QelIcon/QelIcon.pri))
+include($$PWD/../QelNumberInput/QelNumberInput.pri))

--- a/QelShow/mainwindow.cpp
+++ b/QelShow/mainwindow.cpp
@@ -12,17 +12,20 @@ MainWindow::MainWindow(QWidget *parent) :
     QTreeWidget *treeWidget = new QTreeWidget(this);
     treeWidget->setHeaderLabel("QtElementUI Show");
 
-    // 创建 QelIconTester 和 QelButtonTester 页面
+    // 创建组件测试页面
     pQelIconTester = new QelIconTester(this);
     pQelButtonTester = new QelButtonTester(this);
+    pQelNumberInputTester = new QelNumberInputTester(this);
 
     // 创建页面与树项映射关系
     pageMap["QelIcon"] = pQelIconTester;
     pageMap["QelButton"] = pQelButtonTester;
+    pageMap["QelNumberInput"] = pQelNumberInputTester;
 
     // 添加树状列表的项目
     addTreeItem(treeWidget, "QelIcon");
     addTreeItem(treeWidget, "QelButton");
+    addTreeItem(treeWidget, "QelNumberInput");
 
     // 将所有页面添加到 QStackedWidget
     for (QWidget *page : pageMap.values()) {

--- a/QelShow/mainwindow.h
+++ b/QelShow/mainwindow.h
@@ -7,6 +7,7 @@
 
 #include "../QelIcon/QelIconTester.h"
 #include "../QelButton/QelButtonTester.h"
+#include "../QelNumberInput/QelNumberInputTester.h"
 
 namespace Ui {
 class MainWindow;
@@ -29,6 +30,7 @@ private:
     QStackedWidget *pStackedWidget;
     QelIconTester  *pQelIconTester = nullptr;
     QelButtonTester *pQelButtonTester = nullptr;
+    QelNumberInputTester *pQelNumberInputTester = nullptr;
 };
 
 #endif // MAINWINDOW_H

--- a/QtElementUI.pro
+++ b/QtElementUI.pro
@@ -3,5 +3,6 @@ TEMPLATE = subdirs
 SUBDIRS += \
     QelIcon \
     QelButton   \
+    QelNumberInput \
     QelShow
 


### PR DESCRIPTION
feat(QtElementUI): 集成QelNumberInput组件

在QtElementUI项目中集成QelNumberInput组件，同时更新相应的项目文件和测试用例。这包括将QelNumberInput.pri文件纳入新组件目录，以及在mainwindow.cpp中为QelNumberInputTester创建测试页面。

BREAKING CHANGE: QelNumberInput组件的引入更新了项目结构，可能影响依赖于之前组件列表的代码。
```