### PR TITLE
refactor(stylehelper): add generic state stylesheet composer

### DIFF
--- a/QelButton/QelButton.cpp
+++ b/QelButton/QelButton.cpp
@@ -222,48 +222,7 @@ void QelButton::updateButtonStyle() {
         break;
     }
 
-    const QelStyleHelper::ButtonStyle normalStyle =
-        QelStyleHelper::buttonStyle(kind, isPlain_, QelVisualState::Normal);
-    const QelStyleHelper::ButtonStyle hoverStyleToken =
-        QelStyleHelper::buttonStyle(kind, isPlain_, QelVisualState::Hover);
-    const QelStyleHelper::ButtonStyle activeStyleToken =
-        QelStyleHelper::buttonStyle(kind, isPlain_, QelVisualState::Active);
-    const QelStyleHelper::ButtonStyle focusStyleToken =
-        QelStyleHelper::buttonStyle(kind, isPlain_, QelVisualState::Focus);
-    const QelStyleHelper::ButtonStyle disabledStyleToken =
-        QelStyleHelper::buttonStyle(kind, isPlain_, QelVisualState::Disabled);
-    const QelStyleHelper::ButtonStyle loadingStyleToken =
-        QelStyleHelper::buttonStyle(kind, isPlain_, QelVisualState::Loading);
-
-    style += QString("QPushButton { background-color: %1; color: %2; border: 1px solid %3;")
-                 .arg(normalStyle.background)
-                 .arg(normalStyle.text)
-                 .arg(normalStyle.border);
-
-    QString hoverStyle = QString("QPushButton:hover { background-color: %1; color: %2; border: 1px solid %3; }")
-                             .arg(hoverStyleToken.background)
-                             .arg(hoverStyleToken.text)
-                             .arg(hoverStyleToken.border);
-
-    QString activeStyle = QString("QPushButton:pressed { background-color: %1; color: %2; border: 1px solid %3; }")
-                              .arg(activeStyleToken.background)
-                              .arg(activeStyleToken.text)
-                              .arg(activeStyleToken.border);
-
-    QString focusStyle = QString("QPushButton:focus { background-color: %1; color: %2; border: 1px solid %3; outline: none; }")
-                             .arg(focusStyleToken.background)
-                             .arg(focusStyleToken.text)
-                             .arg(focusStyleToken.border);
-
-    QString disabledStyle = QString("QPushButton:disabled { background-color: %1; color: %2; border: 1px solid %3; }")
-                                .arg(disabledStyleToken.background)
-                                .arg(disabledStyleToken.text)
-                                .arg(disabledStyleToken.border);
-
-    QString loadingStyle = QString("QPushButton[qel-loading=\"true\"] { background-color: %1; color: %2; border: 1px solid %3; }")
-                               .arg(loadingStyleToken.background)
-                               .arg(loadingStyleToken.text)
-                               .arg(loadingStyleToken.border);
+    style += QelStyleHelper::buttonStateStyleSheet(kind, isPlain_);
 
     switch (size_) {
     case Large: style += " font-size: 16px; padding: 10px 20px;"; break;
@@ -286,11 +245,6 @@ void QelButton::updateButtonStyle() {
     }
 
     style += roundQSS + " }";
-    style += hoverStyle;
-    style += activeStyle;
-    style += focusStyle;
-    style += disabledStyle;
-    style += loadingStyle;
 
     this->setStyleSheet(style);
 }

--- a/QelButton/QelButton.cpp
+++ b/QelButton/QelButton.cpp
@@ -184,9 +184,9 @@ void QelButton::setAutofocus(bool autofocus) {
 void QelButton::setNativeType(NativeButtonType nativeType) {
     nativeType_ = nativeType;
     // 设置为表单按钮类型（submit, reset, button）
-    if (nativeType == Submit) {
+    if (nativeType == NativeButtonType::Submit) {
         setProperty("type", "submit");
-    } else if (nativeType == Reset) {
+    } else if (nativeType == NativeButtonType::Reset) {
         setProperty("type", "reset");
     } else {
         setProperty("type", "button");
@@ -198,25 +198,25 @@ void QelButton::updateButtonStyle() {
 
     QelTheme::ButtonKind kind = QelTheme::ButtonKind::Default;
     switch (type_) {
-    case Primary:
+    case ButtonType::Primary:
         kind = QelTheme::ButtonKind::Primary;
         break;
-    case Success:
+    case ButtonType::Success:
         kind = QelTheme::ButtonKind::Success;
         break;
-    case Warning:
+    case ButtonType::Warning:
         kind = QelTheme::ButtonKind::Warning;
         break;
-    case Danger:
+    case ButtonType::Danger:
         kind = QelTheme::ButtonKind::Danger;
         break;
-    case Info:
+    case ButtonType::Info:
         kind = QelTheme::ButtonKind::Info;
         break;
-    case Text:
+    case ButtonType::Text:
         kind = QelTheme::ButtonKind::Text;
         break;
-    case Default:
+    case ButtonType::Default:
     default:
         kind = QelTheme::ButtonKind::Default;
         break;
@@ -226,10 +226,10 @@ void QelButton::updateButtonStyle() {
 
     QString sizeStyle;
     switch (size_) {
-    case Large: sizeStyle = "font-size: 16px; padding: 10px 20px;"; break;
-    case Medium: sizeStyle = "font-size: 14px; padding: 8px 16px;"; break;
-    case Small: sizeStyle = "font-size: 12px; padding: 6px 12px;"; break;
-    case Mini: sizeStyle = "font-size: 10px; padding: 4px 8px;"; break;
+    case ButtonSize::Large: sizeStyle = "font-size: 16px; padding: 10px 20px;"; break;
+    case ButtonSize::Medium: sizeStyle = "font-size: 14px; padding: 8px 16px;"; break;
+    case ButtonSize::Small: sizeStyle = "font-size: 12px; padding: 6px 12px;"; break;
+    case ButtonSize::Mini: sizeStyle = "font-size: 10px; padding: 4px 8px;"; break;
     }
 
     QString roundStyle;

--- a/QelButton/QelButton.cpp
+++ b/QelButton/QelButton.cpp
@@ -91,11 +91,15 @@ void applyTextLikeStyle(QelStyleHelper::StateStyleSet &styles,
     const QString hoverText = semantic.lighter(115).name();
     const QString disabledText = semantic.lighter(150).name();
 
-    styles.normal.background = "transparent";
+    const QString basicHoverBg = "#ecf5ff";
+    const QString alwaysOnBg = "#f4f4f5";
+    const QString alwaysOnHoverBg = "#e4e7ed";
+
+    styles.normal.background = hasBackground ? alwaysOnBg : "transparent";
     styles.normal.border = "transparent";
     styles.normal.text = normalText;
 
-    styles.hover.background = hasBackground ? "#F2F3F5" : "transparent";
+    styles.hover.background = hasBackground ? alwaysOnHoverBg : basicHoverBg;
     styles.hover.border = "transparent";
     styles.hover.text = hoverText;
 
@@ -105,7 +109,7 @@ void applyTextLikeStyle(QelStyleHelper::StateStyleSet &styles,
     styles.focus.border = "transparent";
     styles.focus.text = styles.hover.text;
 
-    styles.disabled.background = "transparent";
+    styles.disabled.background = hasBackground ? alwaysOnBg : "transparent";
     styles.disabled.border = "transparent";
     styles.disabled.text = disabledText;
 

--- a/QelButton/QelButton.cpp
+++ b/QelButton/QelButton.cpp
@@ -224,27 +224,28 @@ void QelButton::updateButtonStyle() {
 
     style += QelStyleHelper::buttonStateStyleSheet(kind, isPlain_);
 
+    QString sizeStyle;
     switch (size_) {
-    case Large: style += " font-size: 16px; padding: 10px 20px;"; break;
-    case Medium: style += " font-size: 14px; padding: 8px 16px;"; break;
-    case Small: style += " font-size: 12px; padding: 6px 12px;"; break;
-    case Mini: style += " font-size: 10px; padding: 4px 8px;"; break;
+    case Large: sizeStyle = "font-size: 16px; padding: 10px 20px;"; break;
+    case Medium: sizeStyle = "font-size: 14px; padding: 8px 16px;"; break;
+    case Small: sizeStyle = "font-size: 12px; padding: 6px 12px;"; break;
+    case Mini: sizeStyle = "font-size: 10px; padding: 4px 8px;"; break;
     }
 
-    QString roundQSS;
+    QString roundStyle;
 
     if (isRound_) {
-        roundQSS = QString(" border-radius: %1px;").arg(this->height()/2);
+        roundStyle = QString("border-radius: %1px;").arg(this->height()/2);
     } else {
-        roundQSS = " border-radius: 4px;";
+        roundStyle = "border-radius: 4px;";
     }
 
     if (isCircle_) {
-        roundQSS = QString(" border-radius: %1px;").arg(this->height()/2);
+        roundStyle = QString("border-radius: %1px;").arg(this->height()/2);
         setFixedWidth(this->height());
     }
 
-    style += roundQSS + " }";
+    style += QString("QPushButton { %1 %2 }").arg(sizeStyle, roundStyle);
 
     this->setStyleSheet(style);
 }

--- a/QelButton/QelButton.cpp
+++ b/QelButton/QelButton.cpp
@@ -132,8 +132,8 @@ QelButton::QelButton(ButtonType type,
                      NativeButtonType nativeType,
                      const QIcon &icon,
                      const QString &text,
-                     QWidget *parent,
-                     bool hasBackground)
+                     bool hasBackground,
+                     QWidget *parent)
     : QPushButton(text, parent)
     , type_(type)
     , size_(size)

--- a/QelButton/QelButton.cpp
+++ b/QelButton/QelButton.cpp
@@ -132,7 +132,8 @@ QelButton::QelButton(ButtonType type,
                      NativeButtonType nativeType,
                      const QIcon &icon,
                      const QString &text,
-                     QWidget *parent)
+                     QWidget *parent,
+                     bool hasBackground)
     : QPushButton(text, parent)
     , type_(type)
     , size_(size)
@@ -141,6 +142,7 @@ QelButton::QelButton(ButtonType type,
     , isCircle_(isCircle)
     , isLoading_(isLoading)
     , nativeType_(nativeType)
+    , hasBackground_(hasBackground)
 {
     setIcon(icon);
     setProperty("qel-loading", isLoading_);

--- a/QelButton/QelButton.cpp
+++ b/QelButton/QelButton.cpp
@@ -266,14 +266,11 @@ void QelButton::updateButtonStyle() {
     case ButtonSize::Large:
         sizeStyle = "font-size: 16px; padding: 10px 20px;";
         break;
-    case ButtonSize::Medium:
+    case ButtonSize::Default:
         sizeStyle = "font-size: 14px; padding: 8px 16px;";
         break;
     case ButtonSize::Small:
         sizeStyle = "font-size: 13px; padding: 6px 12px;";
-        break;
-    case ButtonSize::Mini:
-        sizeStyle = "font-size: 12px; padding: 4px 8px;";
         break;
     }
 

--- a/QelButton/QelButton.cpp
+++ b/QelButton/QelButton.cpp
@@ -132,7 +132,7 @@ QelButton::QelButton(ButtonType type,
                      NativeButtonType nativeType,
                      const QIcon &icon,
                      const QString &text,
-                     bool hasBackground,
+                     bool bg,
                      QWidget *parent)
     : QPushButton(text, parent)
     , type_(type)
@@ -142,7 +142,7 @@ QelButton::QelButton(ButtonType type,
     , isCircle_(isCircle)
     , isLoading_(isLoading)
     , nativeType_(nativeType)
-    , hasBackground_(hasBackground)
+    , hasBackground_(bg)
 {
     setIcon(icon);
     setProperty("qel-loading", isLoading_);

--- a/QelButton/QelButton.cpp
+++ b/QelButton/QelButton.cpp
@@ -1,115 +1,102 @@
 #include "QelButton.h"
-#include "../QelTheme/QelTheme.h"
+
+#include <QColor>
+
 #include "../QelStyleHelper/QelStyleHelper.h"
+#include "../QelTheme/QelTheme.h"
 
 namespace qel
 {
 
-//QelButton::QelButton(QWidget *parent,
-//                     QString text,
-//                     ButtonSize btnSize,
-//                     ButtonType btnType,
-//                     bool isPlain,
-//                     bool isRound,
-//                     bool isCircle,
-//                     bool isDisabled,
-//                     bool isLoading)
-//    : QPushButton(parent),
-//      btn_text_(text),
-//      btn_size_(btnSize),
-//      btn_type_(btnType),
-//      is_plain_(isPlain),
-//      is_round_(isRound),
-//      is_circle_(isCircle),
-//      is_loading_(isLoading),
-//      is_disabled_(isDisabled)
-//{
-//    this->updateStyle();
-//}
+namespace {
 
-//QelButton::~QelButton()
-//{
+QelTheme::ButtonKind toButtonKind(QelButton::ButtonType type)
+{
+    switch (type) {
+    case QelButton::ButtonType::Primary:
+        return QelTheme::ButtonKind::Primary;
+    case QelButton::ButtonType::Success:
+        return QelTheme::ButtonKind::Success;
+    case QelButton::ButtonType::Warning:
+        return QelTheme::ButtonKind::Warning;
+    case QelButton::ButtonType::Danger:
+        return QelTheme::ButtonKind::Danger;
+    case QelButton::ButtonType::Info:
+        return QelTheme::ButtonKind::Info;
+    case QelButton::ButtonType::Default:
+    default:
+        return QelTheme::ButtonKind::Default;
+    }
+}
 
-//}
+QColor parseColorOrDefault(const QString &input, const QString &fallback)
+{
+    const QColor fromInput(input);
+    if (fromInput.isValid()) {
+        return fromInput;
+    }
 
-//ButtonSize QelButton::getSize()
-//{
+    return QColor(fallback);
+}
 
-//    return ButtonSize::Medium;
-//}
+void applyCustomColor(QelStyleHelper::StateStyleSet &styles, const QString &color, bool dark)
+{
+    const QColor base = parseColorOrDefault(color, "#409EFF");
+    const QColor hover = base.lighter(112);
+    const QColor disabled = base.lighter(140);
+    const QString textColor = dark ? "#FFFFFF" : "#FFFFFF";
 
-//void QelButton::updateStyle()
-//{
-//    switch (btn_size_) {
-//    case ButtonSize::Medium:
-//        this->setFixedSize(98, 36);
-//        break;
-//    case ButtonSize::Small:
-//        this->setFixedSize(80, 32);
-//        break;
-//    case ButtonSize::Mini:
-//        this->setFixedSize(80, 28);
-//        break;
-//    default:
-//        break;
-//    }
+    styles.normal.background = base.name();
+    styles.normal.border = base.name();
+    styles.normal.text = textColor;
 
-//    QString type_qss = "";
-//    QString hover_qss = "";
-//    QString pressed_qss = "";
-//    QString type_hover_qss = "";
+    styles.hover.background = hover.name();
+    styles.hover.border = hover.name();
+    styles.hover.text = textColor;
 
-//    switch (btn_type_)
-//    {
-//    case qel::ButtonType::Default:
-//        type_qss = QString("color:#606266;background-color:%1; border: 1px solid #dcdfe6;").arg(MACRO_STR(DEFAULT_COLOR));
-//        type_hover_qss = QString("color:#606266;background-color:%1;").arg(MACRO_STR(DEFAULT_HOVER_COLOR));
-//        break;
-//        break;
-//    case qel::ButtonType::Warning:
-//        break;
-//    case qel::ButtonType::Danger:
-//        break;
-//    case qel::ButtonType::Info:
-//        break;
-//    case qel::ButtonType::Text:
-//        break;
-//    case ButtonType::Primary:
-//        type_qss = QString("color:white;background-color:#%1;").arg(MACRO_STR(PRIMARY_COLOR));
-//        type_hover_qss = QString("color:white;background-color:#%1;").arg(MACRO_STR(PRIMARY_HOVER_COLOR));
-//        break;
-//    case ButtonType::Success:
-//        type_qss = QString("color:white;background-color:#%1;").arg(MACRO_STR(SUCCESS_COLOR));
-//        type_hover_qss = QString("color:white;background-color:#%1;").arg(MACRO_STR(SUCCESS_HOVER_COLOR));
-//        break;
-//    default:
-//        break;
-//    }
+    styles.active = styles.hover;
 
+    styles.disabled.background = disabled.name();
+    styles.disabled.border = disabled.name();
+    styles.disabled.text = "#FFFFFF";
 
-//    QString round_qss;
-//    if (is_round_)
-//        round_qss = QString("border-radius:%1px;").arg(QString::number(this->height()/2));
-//    else
-//        round_qss = QString("border-radius:4px;");
+    styles.loading = styles.disabled;
+}
 
-//    if (is_circle_)
-//    {
-//        round_qss = QString("border-radius:%1px;").arg(QString::number(this->height()/2));
-//        this->setFixedWidth(this->height());
-//    }
+void applyTextLikeStyle(QelStyleHelper::StateStyleSet &styles,
+                        bool isLink,
+                        bool hasBackground)
+{
+    const QString baseColor = styles.normal.background;
+    const QColor semantic(baseColor);
+    const QString hoverText = semantic.isValid() ? semantic.lighter(112).name() : "#66B1FF";
+    const QString disabledText = semantic.isValid() ? semantic.lighter(135).name() : "#A0CFFF";
 
-//    this->setStyleSheet(QString("QPushButton{")
-//                        + type_qss
-//                        + round_qss
-//                        + "}"
-//                        + "QPushButton:hover{"
-//                        + type_hover_qss
-//                        + round_qss
-//                        + "}");
+    styles.normal.background = "transparent";
+    styles.normal.border = "transparent";
 
-//   this->setText(btn_text_);
-//}
+    styles.hover.background = hasBackground ? "#ECF5FF" : "transparent";
+    styles.hover.border = "transparent";
+    styles.hover.text = hoverText;
+
+    styles.active = styles.hover;
+
+    styles.focus.background = styles.hover.background;
+    styles.focus.border = "transparent";
+
+    styles.disabled.background = "transparent";
+    styles.disabled.border = "transparent";
+    styles.disabled.text = disabledText;
+
+    styles.loading = styles.disabled;
+
+    if (isLink) {
+        styles.hover.background = "transparent";
+        styles.focus.background = "transparent";
+    }
+}
+
+} // namespace
 
 QelButton::QelButton(ButtonType type,
                      ButtonSize size,
@@ -121,14 +108,14 @@ QelButton::QelButton(ButtonType type,
                      const QIcon &icon,
                      const QString &text,
                      QWidget *parent)
-    : QPushButton(text, parent),
-    type_(type),
-    size_(size),
-    isPlain_(isPlain),
-    isRound_(isRound),
-    isCircle_(isCircle),
-    isLoading_(isLoading),
-    nativeType_(nativeType)
+    : QPushButton(text, parent)
+    , type_(type)
+    , size_(size)
+    , isPlain_(isPlain)
+    , isRound_(isRound)
+    , isCircle_(isCircle)
+    , isLoading_(isLoading)
+    , nativeType_(nativeType)
 {
     setIcon(icon);
     setProperty("qel-loading", isLoading_);
@@ -183,7 +170,6 @@ void QelButton::setAutofocus(bool autofocus) {
 
 void QelButton::setNativeType(NativeButtonType nativeType) {
     nativeType_ = nativeType;
-    // 设置为表单按钮类型（submit, reset, button）
     if (nativeType == NativeButtonType::Submit) {
         setProperty("type", "submit");
     } else if (nativeType == NativeButtonType::Reset) {
@@ -193,63 +179,96 @@ void QelButton::setNativeType(NativeButtonType nativeType) {
     }
 }
 
+void QelButton::setVisualType(VisualType visualType)
+{
+    visualType_ = visualType;
+    updateButtonStyle();
+}
+
+void QelButton::setTextMode(bool isTextMode)
+{
+    visualType_ = isTextMode ? VisualType::Text : VisualType::Filled;
+    updateButtonStyle();
+}
+
+void QelButton::setLinkMode(bool isLinkMode)
+{
+    visualType_ = isLinkMode ? VisualType::Link : VisualType::Filled;
+    updateButtonStyle();
+}
+
+void QelButton::setBg(bool hasBackground)
+{
+    hasBackground_ = hasBackground;
+    updateButtonStyle();
+}
+
+void QelButton::setColor(const QString &color)
+{
+    customColor_ = color;
+    updateButtonStyle();
+}
+
+void QelButton::setDark(bool dark)
+{
+    dark_ = dark;
+    updateButtonStyle();
+}
+
 void QelButton::updateButtonStyle() {
     QString style;
 
-    QelTheme::ButtonKind kind = QelTheme::ButtonKind::Default;
-    switch (type_) {
-    case ButtonType::Primary:
-        kind = QelTheme::ButtonKind::Primary;
-        break;
-    case ButtonType::Success:
-        kind = QelTheme::ButtonKind::Success;
-        break;
-    case ButtonType::Warning:
-        kind = QelTheme::ButtonKind::Warning;
-        break;
-    case ButtonType::Danger:
-        kind = QelTheme::ButtonKind::Danger;
-        break;
-    case ButtonType::Info:
-        kind = QelTheme::ButtonKind::Info;
-        break;
-    case ButtonType::Text:
-        kind = QelTheme::ButtonKind::Text;
-        break;
-    case ButtonType::Default:
-    default:
-        kind = QelTheme::ButtonKind::Default;
-        break;
+    const QelTheme::ButtonKind kind = toButtonKind(type_);
+    QelStyleHelper::StateStyleSet styles = QelStyleHelper::buttonStateStyles(kind, isPlain_);
+
+    if (!customColor_.isEmpty()) {
+        applyCustomColor(styles, customColor_, dark_);
     }
 
-    style += QelStyleHelper::buttonStateStyleSheet(kind, isPlain_);
+    if (visualType_ == VisualType::Text || visualType_ == VisualType::Link) {
+        applyTextLikeStyle(styles, visualType_ == VisualType::Link, hasBackground_);
+    }
+
+    style += QelStyleHelper::composeStateStyleSheet("QPushButton",
+                                                    "QPushButton[qel-loading=\"true\"]",
+                                                    styles,
+                                                    true);
 
     QString sizeStyle;
     switch (size_) {
-    case ButtonSize::Large: sizeStyle = "font-size: 16px; padding: 10px 20px;"; break;
-    case ButtonSize::Medium: sizeStyle = "font-size: 14px; padding: 8px 16px;"; break;
-    case ButtonSize::Small: sizeStyle = "font-size: 12px; padding: 6px 12px;"; break;
-    case ButtonSize::Mini: sizeStyle = "font-size: 10px; padding: 4px 8px;"; break;
+    case ButtonSize::Large:
+        sizeStyle = "font-size: 16px; padding: 10px 20px;";
+        break;
+    case ButtonSize::Medium:
+        sizeStyle = "font-size: 14px; padding: 8px 16px;";
+        break;
+    case ButtonSize::Small:
+        sizeStyle = "font-size: 12px; padding: 6px 12px;";
+        break;
+    case ButtonSize::Mini:
+        sizeStyle = "font-size: 10px; padding: 4px 8px;";
+        break;
     }
 
     QString roundStyle;
-
     if (isRound_) {
-        roundStyle = QString("border-radius: %1px;").arg(this->height()/2);
+        roundStyle = QString("border-radius: %1px;").arg(this->height() / 2);
     } else {
         roundStyle = "border-radius: 4px;";
     }
 
     if (isCircle_) {
-        roundStyle = QString("border-radius: %1px;").arg(this->height()/2);
+        roundStyle = QString("border-radius: %1px;").arg(this->height() / 2);
         setFixedWidth(this->height());
     }
 
     style += QString("QPushButton { %1 %2 }").arg(sizeStyle, roundStyle);
 
+    if (visualType_ == VisualType::Link) {
+        style += "QPushButton:hover { text-decoration: underline; }";
+    }
+
     this->setStyleSheet(style);
 }
-
-
 
 }   // namespace qel

--- a/QelButton/QelButton.cpp
+++ b/QelButton/QelButton.cpp
@@ -29,30 +29,48 @@ QelTheme::ButtonKind toButtonKind(QelButton::ButtonType type)
     }
 }
 
-QColor parseColorOrDefault(const QString &input, const QString &fallback)
+QColor semanticColor(QelButton::ButtonType type)
+{
+    switch (type) {
+    case QelButton::ButtonType::Primary:
+        return QColor("#409EFF");
+    case QelButton::ButtonType::Success:
+        return QColor("#67C23A");
+    case QelButton::ButtonType::Warning:
+        return QColor("#E6A23C");
+    case QelButton::ButtonType::Danger:
+        return QColor("#F56C6C");
+    case QelButton::ButtonType::Info:
+        return QColor("#909399");
+    case QelButton::ButtonType::Default:
+    default:
+        return QColor("#606266");
+    }
+}
+
+QColor parseColorOrDefault(const QString &input, const QColor &fallback)
 {
     const QColor fromInput(input);
     if (fromInput.isValid()) {
         return fromInput;
     }
 
-    return QColor(fallback);
+    return fallback;
 }
 
-void applyCustomColor(QelStyleHelper::StateStyleSet &styles, const QString &color, bool dark)
+void applyCustomColor(QelStyleHelper::StateStyleSet &styles, const QString &color)
 {
-    const QColor base = parseColorOrDefault(color, "#409EFF");
-    const QColor hover = base.lighter(112);
-    const QColor disabled = base.lighter(140);
-    const QString textColor = dark ? "#FFFFFF" : "#FFFFFF";
+    const QColor base = parseColorOrDefault(color, QColor("#409EFF"));
+    const QColor hover = base.lighter(110);
+    const QColor disabled = base.lighter(138);
 
     styles.normal.background = base.name();
     styles.normal.border = base.name();
-    styles.normal.text = textColor;
+    styles.normal.text = "#FFFFFF";
 
     styles.hover.background = hover.name();
     styles.hover.border = hover.name();
-    styles.hover.text = textColor;
+    styles.hover.text = "#FFFFFF";
 
     styles.active = styles.hover;
 
@@ -64,18 +82,20 @@ void applyCustomColor(QelStyleHelper::StateStyleSet &styles, const QString &colo
 }
 
 void applyTextLikeStyle(QelStyleHelper::StateStyleSet &styles,
+                        QelButton::ButtonType type,
                         bool isLink,
                         bool hasBackground)
 {
-    const QString baseColor = styles.normal.background;
-    const QColor semantic(baseColor);
-    const QString hoverText = semantic.isValid() ? semantic.lighter(112).name() : "#66B1FF";
-    const QString disabledText = semantic.isValid() ? semantic.lighter(135).name() : "#A0CFFF";
+    const QColor semantic = semanticColor(type);
+    const QString normalText = semantic.name();
+    const QString hoverText = semantic.lighter(115).name();
+    const QString disabledText = semantic.lighter(150).name();
 
     styles.normal.background = "transparent";
     styles.normal.border = "transparent";
+    styles.normal.text = normalText;
 
-    styles.hover.background = hasBackground ? "#ECF5FF" : "transparent";
+    styles.hover.background = hasBackground ? "#F2F3F5" : "transparent";
     styles.hover.border = "transparent";
     styles.hover.text = hoverText;
 
@@ -83,6 +103,7 @@ void applyTextLikeStyle(QelStyleHelper::StateStyleSet &styles,
 
     styles.focus.background = styles.hover.background;
     styles.focus.border = "transparent";
+    styles.focus.text = styles.hover.text;
 
     styles.disabled.background = "transparent";
     styles.disabled.border = "transparent";
@@ -120,6 +141,7 @@ QelButton::QelButton(ButtonType type,
     setIcon(icon);
     setProperty("qel-loading", isLoading_);
     setEnabled(!isLoading_);
+    setCursor(Qt::PointingHandCursor);
     updateButtonStyle();
 }
 
@@ -212,6 +234,7 @@ void QelButton::setColor(const QString &color)
 void QelButton::setDark(bool dark)
 {
     dark_ = dark;
+    Q_UNUSED(dark_);
     updateButtonStyle();
 }
 
@@ -222,11 +245,11 @@ void QelButton::updateButtonStyle() {
     QelStyleHelper::StateStyleSet styles = QelStyleHelper::buttonStateStyles(kind, isPlain_);
 
     if (!customColor_.isEmpty()) {
-        applyCustomColor(styles, customColor_, dark_);
+        applyCustomColor(styles, customColor_);
     }
 
     if (visualType_ == VisualType::Text || visualType_ == VisualType::Link) {
-        applyTextLikeStyle(styles, visualType_ == VisualType::Link, hasBackground_);
+        applyTextLikeStyle(styles, type_, visualType_ == VisualType::Link, hasBackground_);
     }
 
     style += QelStyleHelper::composeStateStyleSheet("QPushButton",
@@ -243,10 +266,10 @@ void QelButton::updateButtonStyle() {
         sizeStyle = "font-size: 14px; padding: 8px 16px;";
         break;
     case ButtonSize::Small:
-        sizeStyle = "font-size: 12px; padding: 6px 12px;";
+        sizeStyle = "font-size: 13px; padding: 6px 12px;";
         break;
     case ButtonSize::Mini:
-        sizeStyle = "font-size: 10px; padding: 4px 8px;";
+        sizeStyle = "font-size: 12px; padding: 4px 8px;";
         break;
     }
 
@@ -255,6 +278,10 @@ void QelButton::updateButtonStyle() {
         roundStyle = QString("border-radius: %1px;").arg(this->height() / 2);
     } else {
         roundStyle = "border-radius: 4px;";
+    }
+
+    if (visualType_ == VisualType::Link) {
+        roundStyle = "border-radius: 0px;";
     }
 
     if (isCircle_) {

--- a/QelButton/QelButton.h
+++ b/QelButton/QelButton.h
@@ -26,9 +26,8 @@ public:
     static constexpr ButtonType Info = ButtonType::Info;
 
     static constexpr ButtonSize Large = ButtonSize::Large;
-    static constexpr ButtonSize Medium = ButtonSize::Medium;
+    static constexpr ButtonSize Default = ButtonSize::Default;
     static constexpr ButtonSize Small = ButtonSize::Small;
-    static constexpr ButtonSize Mini = ButtonSize::Mini;
 
     static constexpr NativeButtonType Button = NativeButtonType::Button;
     static constexpr NativeButtonType Submit = NativeButtonType::Submit;
@@ -39,7 +38,7 @@ public:
     static constexpr VisualType Link = VisualType::Link;
 
     explicit QelButton(ButtonType type = ButtonType::Default,
-                       ButtonSize size = ButtonSize::Medium,
+                       ButtonSize size = ButtonSize::Default,
                        bool isPlain = false,
                        bool isRound = false,
                        bool isCircle = false,

--- a/QelButton/QelButton.h
+++ b/QelButton/QelButton.h
@@ -7,6 +7,8 @@
 #include <QVariant>
 #include <QPushButton>
 
+#include "../QelCommon/QelControlTypes.h"
+
 // get value from https://element-plus.gitee.io/#/en-US/component/color
 #define PRIMARY_COLOR "409EFF"
 #define SUCCESS_COLOR "67C23A"
@@ -44,114 +46,39 @@
 namespace qel
 {
 
-enum class ButtonSize {
-    Medium = 0,
-    Small  = 1,
-    Mini   = 2
-};
-
-enum class ButtonType {
-    Default = 0,
-    Primary = 1,
-    Success = 2,
-    Warning = 3,
-    Danger  = 4,
-    Info    = 5,
-    Text    = 6
-};
-
-typedef struct ButtonColor_ {
-    QString normal_color;
-    QString hover_color;
-    QString plain_color;
-} ButtonColor;
-
-const int SizeMedium = 0x1;
-const int SizeSmall  = 0x2;
-const int SizeMini   = 0x4;
-
-const int TypePrimary = 0x10;
-const int TypeSuccess = 0x20;
-const int TypeWarning = 0x40;
-const int TypeDanger  = 0x80;
-const int TypeInfo    = 0x100;
-const int TypeText    = 0x200;
-
-const int Plain    = 0x1000;
-const int Round    = 0x2000;
-const int Circle   = 0x4000;
-const int Loading  = 0x8000;
-const int Disabled = 0x10000;
-
-//class QelButton : public QPushButton
-//{
-//    Q_OBJECT
-
-//public:
-//    QelButton(QWidget *parent = 0,
-//              QString    text    = "",
-//              ButtonSize btnSize = ButtonSize::Medium,
-//              ButtonType btnType = ButtonType::Default,
-//              bool isPlain = false,
-//              bool isRound = false,
-//              bool isCircle = false,
-//              bool isDisabled = false,
-//              bool isLoading = false
-//              );
-//    ~QelButton();
-
-
-//public:
-
-
-//private:
-//    ButtonSize getSize();
-//    ButtonType getType();
-//    void updateStyle();
-
-//private:
-//    QString    btn_text_;
-//    ButtonSize btn_size_;
-//    ButtonType btn_type_;
-//    bool       is_plain_    = false;
-//    bool       is_round_    = false;
-//    bool       is_circle_   = false;
-//    bool       is_loading_  = false;
-//    bool       is_disabled_ = false;
-
-//    QMap<ButtonType, ButtonColor> btn_colors_ = {
-//        {ButtonType::Default, {"#FFFFFF", "#ECF5FF", "#FFFFFF"}},
-//        {ButtonType::Primary, {"#409EFF", "#66B1FF", "#3A8EE6"}},
-//        {ButtonType::Success, {"#67C23A", "#85CE61", "#5DAF34"}},
-//        {ButtonType::Info,    {"#909399", "#A6A9AD", "#82848A"}},
-//        {ButtonType::Warning, {"#E6A23C", "#EBB563", "#CF9236"}},
-//        {ButtonType::Danger,  {"#F56C6C", "#F78989", "#DD6161"}}
-
-//    };
-//    QMap<ButtonType, QString> hover_color_;
-//    QMap<ButtonType, QString> plain_color_;
-//    QVariantMap options_;
-//    QMap<QString, ButtonSize> map_size_str_;
-//    QMap<ButtonSize, QSize>   map_size_;
-
-//};
-
 class QelButton : public QPushButton {
     Q_OBJECT
 
 public:
-    enum ButtonType { Default, Primary, Success, Warning, Danger, Info, Text };
-    enum ButtonSize { Large, Medium, Small, Mini };
-    enum NativeButtonType { Button, Submit, Reset };
+    using ButtonType = QelButtonType;
+    using ButtonSize = QelControlSize;
+    using NativeButtonType = QelNativeButtonType;
+
+    static constexpr ButtonType Default = ButtonType::Default;
+    static constexpr ButtonType Primary = ButtonType::Primary;
+    static constexpr ButtonType Success = ButtonType::Success;
+    static constexpr ButtonType Warning = ButtonType::Warning;
+    static constexpr ButtonType Danger = ButtonType::Danger;
+    static constexpr ButtonType Info = ButtonType::Info;
+    static constexpr ButtonType Text = ButtonType::Text;
+
+    static constexpr ButtonSize Large = ButtonSize::Large;
+    static constexpr ButtonSize Medium = ButtonSize::Medium;
+    static constexpr ButtonSize Small = ButtonSize::Small;
+    static constexpr ButtonSize Mini = ButtonSize::Mini;
+
+    static constexpr NativeButtonType Button = NativeButtonType::Button;
+    static constexpr NativeButtonType Submit = NativeButtonType::Submit;
+    static constexpr NativeButtonType Reset = NativeButtonType::Reset;
 
             // 构造函数带参数
-    explicit QelButton(ButtonType type = Default,
-                       ButtonSize size = Medium,
+    explicit QelButton(ButtonType type = ButtonType::Default,
+                       ButtonSize size = ButtonSize::Medium,
                        bool isPlain = false,
                        bool isRound = false,
                        bool isCircle = false,
                        bool isLoading = false,
-                       NativeButtonType nativeType = Button,
+                       NativeButtonType nativeType = NativeButtonType::Button,
                        const QIcon &icon = QIcon(),
                        const QString &text = QString(),
                        QWidget *parent = nullptr);

--- a/QelButton/QelButton.h
+++ b/QelButton/QelButton.h
@@ -46,7 +46,7 @@ public:
                        NativeButtonType nativeType = NativeButtonType::Button,
                        const QIcon &icon = QIcon(),
                        const QString &text = QString(),
-                       bool hasBackground = false,
+                       bool bg = false,
                        QWidget *parent = nullptr);
 
     void setType(ButtonType type);

--- a/QelButton/QelButton.h
+++ b/QelButton/QelButton.h
@@ -1,47 +1,10 @@
 #ifndef QELBUTTON_H
 #define QELBUTTON_H
 
-#include <QMap>
-#include <QString>
-#include <QWidget>
-#include <QVariant>
 #include <QPushButton>
+#include <QString>
 
 #include "../QelCommon/QelControlTypes.h"
-
-// get value from https://element-plus.gitee.io/#/en-US/component/color
-#define PRIMARY_COLOR "409EFF"
-#define SUCCESS_COLOR "67C23A"
-#define INFO_COLOR    "909399"
-#define WARNING_COLOR "E6A23C"
-#define DANGER_COLOR  "F56C6C"
-#define DEFAULT_COLOR "FFFFFF"
-
-#define DEFAULT_HOVER_COLOR "#ECF5FF"
-#define PRIMARY_HOVER_COLOR "#66B1FF"
-#define SUCCESS_HOVER_COLOR "#85CE61"
-#define INFO_HOVER_COLOR    "#A6A9AD"
-#define WARNING_HOVER_COLOR "#EBB563"
-#define DANGER_HOVER_COLOR  "#F78989"
-
-#define PRIMARY_PLAIN_COLOR "3A8EE6"
-#define SUCCESS_PLAIN_COLOR "5DAF34"
-#define INFO_PLAIN_COLOR    "82848A"
-#define WARNING_PLAIN_COLOR "CF9236"
-#define DANGER_PLAIN_COLOR  "DD6161"
-#
-#define PRIMARY_TEXT_COLOR     "303133"
-#define REGULAR_TEXT_COLOR     "606266"
-#define SECONDARY_TEXT_COLOR   "909399"
-#define PLACEHORDER_TEXT_COLOR "C0C4CC"
-
-#define BASE_BORDER_COLOR           "DCDFE6"
-#define LIGHT_BORDER_COLOR          "E4E7ED"
-#define LIGHTER_BORDER_COLOR        "EBEEF5"
-#define EXTRA_LIGHT_BORDER_COLOR    "F2F6FC"
-
-#define STR(R)          #R
-#define MACRO_STR(R)    STR(R)
 
 namespace qel
 {
@@ -53,6 +16,7 @@ public:
     using ButtonType = QelButtonType;
     using ButtonSize = QelControlSize;
     using NativeButtonType = QelNativeButtonType;
+    using VisualType = QelButtonVisualType;
 
     static constexpr ButtonType Default = ButtonType::Default;
     static constexpr ButtonType Primary = ButtonType::Primary;
@@ -60,7 +24,6 @@ public:
     static constexpr ButtonType Warning = ButtonType::Warning;
     static constexpr ButtonType Danger = ButtonType::Danger;
     static constexpr ButtonType Info = ButtonType::Info;
-    static constexpr ButtonType Text = ButtonType::Text;
 
     static constexpr ButtonSize Large = ButtonSize::Large;
     static constexpr ButtonSize Medium = ButtonSize::Medium;
@@ -71,7 +34,10 @@ public:
     static constexpr NativeButtonType Submit = NativeButtonType::Submit;
     static constexpr NativeButtonType Reset = NativeButtonType::Reset;
 
-            // 构造函数带参数
+    static constexpr VisualType Filled = VisualType::Filled;
+    static constexpr VisualType Text = VisualType::Text;
+    static constexpr VisualType Link = VisualType::Link;
+
     explicit QelButton(ButtonType type = ButtonType::Default,
                        ButtonSize size = ButtonSize::Medium,
                        bool isPlain = false,
@@ -83,7 +49,6 @@ public:
                        const QString &text = QString(),
                        QWidget *parent = nullptr);
 
-            // Getter 和 Setter
     void setType(ButtonType type);
     void setSize(ButtonSize size);
     void setPlain(bool isPlain);
@@ -95,6 +60,14 @@ public:
     void setAutofocus(bool autofocus);
     void setNativeType(NativeButtonType nativeType);
 
+    // Element Plus inspired additions.
+    void setVisualType(VisualType visualType);
+    void setTextMode(bool isTextMode);
+    void setLinkMode(bool isLinkMode);
+    void setBg(bool hasBackground);
+    void setColor(const QString &color);
+    void setDark(bool dark);
+
 private:
     ButtonType type_;
     ButtonSize size_;
@@ -104,10 +77,14 @@ private:
     bool isLoading_;
     NativeButtonType nativeType_;
 
+    VisualType visualType_ = VisualType::Filled;
+    bool hasBackground_ = false;
+    QString customColor_;
+    bool dark_ = false;
+
     void updateButtonStyle();
 };
 
 } // namespace qel
-
 
 #endif // QELBUTTON_H

--- a/QelButton/QelButton.h
+++ b/QelButton/QelButton.h
@@ -46,8 +46,8 @@ public:
                        NativeButtonType nativeType = NativeButtonType::Button,
                        const QIcon &icon = QIcon(),
                        const QString &text = QString(),
-                       QWidget *parent = nullptr,
-                       bool hasBackground = false);
+                       bool hasBackground = false,
+                       QWidget *parent = nullptr);
 
     void setType(ButtonType type);
     void setSize(ButtonSize size);

--- a/QelButton/QelButton.h
+++ b/QelButton/QelButton.h
@@ -25,9 +25,9 @@ public:
     static constexpr ButtonType Danger = ButtonType::Danger;
     static constexpr ButtonType Info = ButtonType::Info;
 
-    static constexpr ButtonSize Large = ButtonSize::Large;
-    static constexpr ButtonSize Default = ButtonSize::Default;
-    static constexpr ButtonSize Small = ButtonSize::Small;
+    static constexpr ButtonSize LargeSize = ButtonSize::Large;
+    static constexpr ButtonSize DefaultSize = ButtonSize::Default;
+    static constexpr ButtonSize SmallSize = ButtonSize::Small;
 
     static constexpr NativeButtonType Button = NativeButtonType::Button;
     static constexpr NativeButtonType Submit = NativeButtonType::Submit;

--- a/QelButton/QelButton.h
+++ b/QelButton/QelButton.h
@@ -46,7 +46,8 @@ public:
                        NativeButtonType nativeType = NativeButtonType::Button,
                        const QIcon &icon = QIcon(),
                        const QString &text = QString(),
-                       QWidget *parent = nullptr);
+                       QWidget *parent = nullptr,
+                       bool hasBackground = false);
 
     void setType(ButtonType type);
     void setSize(ButtonSize size);

--- a/QelButton/QelButton.pri
+++ b/QelButton/QelButton.pri
@@ -2,7 +2,8 @@ SOURCES += \
         $$PWD/QelButton.cpp
 
 HEADERS += \
-        $$PWD/QelButton.h
+        $$PWD/QelButton.h \
+        $$PWD/../QelCommon/QelControlTypes.h
 
 include($$PWD/../QelTheme/QelTheme.pri)
 

--- a/QelButton/QelButton.pro
+++ b/QelButton/QelButton.pro
@@ -29,7 +29,8 @@ SOURCES += \
 
 HEADERS += \
         QelButton.h \
-        QelButtonTester.h
+        QelButtonTester.h \
+        ../QelCommon/QelControlTypes.h
 
 DISTFILES += \
     QelButton.pri

--- a/QelButton/QelButtonTester.h
+++ b/QelButton/QelButtonTester.h
@@ -24,29 +24,29 @@ public:
         QVBoxLayout *mainLayout = new QVBoxLayout(this);
 
         QList<QelButton *> defaultButtons;
-        defaultButtons.append(new QelButton(QelButton::Default, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Default", this));
-        defaultButtons.append(new QelButton(QelButton::Primary, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Primary", this));
-        defaultButtons.append(new QelButton(QelButton::Success, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Success", this));
-        defaultButtons.append(new QelButton(QelButton::Info, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Info", this));
-        defaultButtons.append(new QelButton(QelButton::Warning, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Warning", this));
-        defaultButtons.append(new QelButton(QelButton::Danger, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Danger", this));
+        defaultButtons.append(new QelButton(QelButton::Default, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Default", this));
+        defaultButtons.append(new QelButton(QelButton::Primary, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Primary", this));
+        defaultButtons.append(new QelButton(QelButton::Success, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Success", this));
+        defaultButtons.append(new QelButton(QelButton::Info, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Info", this));
+        defaultButtons.append(new QelButton(QelButton::Warning, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Warning", this));
+        defaultButtons.append(new QelButton(QelButton::Danger, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Danger", this));
         addButtonRow(mainLayout, "Default Buttons", defaultButtons);
 
         QList<QelButton *> plainButtons;
-        plainButtons.append(new QelButton(QelButton::Default, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Plain", this));
-        plainButtons.append(new QelButton(QelButton::Primary, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Primary", this));
-        plainButtons.append(new QelButton(QelButton::Success, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Success", this));
-        plainButtons.append(new QelButton(QelButton::Info, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Info", this));
-        plainButtons.append(new QelButton(QelButton::Warning, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Warning", this));
-        plainButtons.append(new QelButton(QelButton::Danger, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Danger", this));
+        plainButtons.append(new QelButton(QelButton::Default, QelButton::Default, true, false, false, false, QelButton::Button, QIcon(), "Plain", this));
+        plainButtons.append(new QelButton(QelButton::Primary, QelButton::Default, true, false, false, false, QelButton::Button, QIcon(), "Primary", this));
+        plainButtons.append(new QelButton(QelButton::Success, QelButton::Default, true, false, false, false, QelButton::Button, QIcon(), "Success", this));
+        plainButtons.append(new QelButton(QelButton::Info, QelButton::Default, true, false, false, false, QelButton::Button, QIcon(), "Info", this));
+        plainButtons.append(new QelButton(QelButton::Warning, QelButton::Default, true, false, false, false, QelButton::Button, QIcon(), "Warning", this));
+        plainButtons.append(new QelButton(QelButton::Danger, QelButton::Default, true, false, false, false, QelButton::Button, QIcon(), "Danger", this));
         addButtonRow(mainLayout, "Plain Buttons", plainButtons);
 
         QList<QelButton *> roundButtons;
-        roundButtons.append(new QelButton(QelButton::Primary, QelButton::Medium, false, true, false, false, QelButton::Button, QIcon(), "Primary", this));
-        roundButtons.append(new QelButton(QelButton::Success, QelButton::Medium, false, true, false, false, QelButton::Button, QIcon(), "Success", this));
-        roundButtons.append(new QelButton(QelButton::Info, QelButton::Medium, false, true, false, false, QelButton::Button, QIcon(), "Info", this));
-        roundButtons.append(new QelButton(QelButton::Warning, QelButton::Medium, false, true, false, false, QelButton::Button, QIcon(), "Warning", this));
-        roundButtons.append(new QelButton(QelButton::Danger, QelButton::Medium, false, true, false, false, QelButton::Button, QIcon(), "Danger", this));
+        roundButtons.append(new QelButton(QelButton::Primary, QelButton::Default, false, true, false, false, QelButton::Button, QIcon(), "Primary", this));
+        roundButtons.append(new QelButton(QelButton::Success, QelButton::Default, false, true, false, false, QelButton::Button, QIcon(), "Success", this));
+        roundButtons.append(new QelButton(QelButton::Info, QelButton::Default, false, true, false, false, QelButton::Button, QIcon(), "Info", this));
+        roundButtons.append(new QelButton(QelButton::Warning, QelButton::Default, false, true, false, false, QelButton::Button, QIcon(), "Warning", this));
+        roundButtons.append(new QelButton(QelButton::Danger, QelButton::Default, false, true, false, false, QelButton::Button, QIcon(), "Danger", this));
         addButtonRow(mainLayout, "Round Buttons", roundButtons);
 
         QList<QelButton *> iconButtons;
@@ -59,33 +59,33 @@ public:
         addButtonRow(mainLayout, "Icon Buttons", iconButtons);
 
         QList<QelButton *> disabledButtons;
-        disabledButtons.append(new QelButton(QelButton::Default, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Default", this));
-        disabledButtons.append(new QelButton(QelButton::Primary, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Primary", this));
-        disabledButtons.append(new QelButton(QelButton::Success, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Success", this));
-        disabledButtons.append(new QelButton(QelButton::Info, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Info", this));
-        disabledButtons.append(new QelButton(QelButton::Warning, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Warning", this));
-        disabledButtons.append(new QelButton(QelButton::Danger, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Danger", this));
+        disabledButtons.append(new QelButton(QelButton::Default, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Default", this));
+        disabledButtons.append(new QelButton(QelButton::Primary, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Primary", this));
+        disabledButtons.append(new QelButton(QelButton::Success, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Success", this));
+        disabledButtons.append(new QelButton(QelButton::Info, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Info", this));
+        disabledButtons.append(new QelButton(QelButton::Warning, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Warning", this));
+        disabledButtons.append(new QelButton(QelButton::Danger, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Danger", this));
         for (QelButton *button : disabledButtons) {
             button->setDisabled(true);
         }
         addButtonRow(mainLayout, "Disabled Buttons", disabledButtons);
 
         QList<QelButton *> disabledPlainButtons;
-        disabledPlainButtons.append(new QelButton(QelButton::Default, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Default", this));
-        disabledPlainButtons.append(new QelButton(QelButton::Primary, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Primary", this));
-        disabledPlainButtons.append(new QelButton(QelButton::Success, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Success", this));
-        disabledPlainButtons.append(new QelButton(QelButton::Info, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Info", this));
-        disabledPlainButtons.append(new QelButton(QelButton::Warning, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Warning", this));
-        disabledPlainButtons.append(new QelButton(QelButton::Danger, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Danger", this));
+        disabledPlainButtons.append(new QelButton(QelButton::Default, QelButton::Default, true, false, false, false, QelButton::Button, QIcon(), "Default", this));
+        disabledPlainButtons.append(new QelButton(QelButton::Primary, QelButton::Default, true, false, false, false, QelButton::Button, QIcon(), "Primary", this));
+        disabledPlainButtons.append(new QelButton(QelButton::Success, QelButton::Default, true, false, false, false, QelButton::Button, QIcon(), "Success", this));
+        disabledPlainButtons.append(new QelButton(QelButton::Info, QelButton::Default, true, false, false, false, QelButton::Button, QIcon(), "Info", this));
+        disabledPlainButtons.append(new QelButton(QelButton::Warning, QelButton::Default, true, false, false, false, QelButton::Button, QIcon(), "Warning", this));
+        disabledPlainButtons.append(new QelButton(QelButton::Danger, QelButton::Default, true, false, false, false, QelButton::Button, QIcon(), "Danger", this));
         for (QelButton *button : disabledPlainButtons) {
             button->setDisabled(true);
         }
         addButtonRow(mainLayout, "Disabled Plain Buttons", disabledPlainButtons);
 
         QList<QelButton *> textButtons;
-        textButtons.append(new QelButton(QelButton::Default, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Default Text", this));
-        textButtons.append(new QelButton(QelButton::Primary, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Primary Text", this));
-        textButtons.append(new QelButton(QelButton::Success, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Success Text", this));
+        textButtons.append(new QelButton(QelButton::Default, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Default Text", this));
+        textButtons.append(new QelButton(QelButton::Primary, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Primary Text", this));
+        textButtons.append(new QelButton(QelButton::Success, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Success Text", this));
         for (QelButton *button : textButtons) {
             button->setTextMode(true);
             button->setBg(true);
@@ -93,18 +93,18 @@ public:
         addButtonRow(mainLayout, "Text Buttons", textButtons);
 
         QList<QelButton *> linkButtons;
-        linkButtons.append(new QelButton(QelButton::Default, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Default Link", this));
-        linkButtons.append(new QelButton(QelButton::Primary, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Primary Link", this));
-        linkButtons.append(new QelButton(QelButton::Danger, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Danger Link", this));
+        linkButtons.append(new QelButton(QelButton::Default, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Default Link", this));
+        linkButtons.append(new QelButton(QelButton::Primary, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Primary Link", this));
+        linkButtons.append(new QelButton(QelButton::Danger, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Danger Link", this));
         for (QelButton *button : linkButtons) {
             button->setLinkMode(true);
         }
         addButtonRow(mainLayout, "Link Buttons", linkButtons);
 
         QList<QelButton *> customColorButtons;
-        QelButton *customTeal = new QelButton(QelButton::Primary, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Custom #13c2c2", this);
+        QelButton *customTeal = new QelButton(QelButton::Primary, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Custom #13c2c2", this);
         customTeal->setColor("#13c2c2");
-        QelButton *customPurple = new QelButton(QelButton::Primary, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Custom #722ed1", this);
+        QelButton *customPurple = new QelButton(QelButton::Primary, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Custom #722ed1", this);
         customPurple->setColor("#722ed1");
         customColorButtons.append(customTeal);
         customColorButtons.append(customPurple);
@@ -112,9 +112,8 @@ public:
 
         QList<QelButton *> sizeButtons;
         sizeButtons.append(new QelButton(QelButton::Primary, QelButton::Large, false, false, false, false, QelButton::Button, QIcon(), "Large", this));
-        sizeButtons.append(new QelButton(QelButton::Primary, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Medium", this));
+        sizeButtons.append(new QelButton(QelButton::Primary, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Default", this));
         sizeButtons.append(new QelButton(QelButton::Primary, QelButton::Small, false, false, false, false, QelButton::Button, QIcon(), "Small", this));
-        sizeButtons.append(new QelButton(QelButton::Primary, QelButton::Mini, false, false, false, false, QelButton::Button, QIcon(), "Mini", this));
         addButtonRow(mainLayout, "Button Sizes", sizeButtons);
 
         addElementPlusLinkTextShowcase(mainLayout);
@@ -220,12 +219,12 @@ private:
     QList<QelButton *> makeElementSemanticButtons(QWidget *parent)
     {
         QList<QelButton *> buttons;
-        buttons.append(new QelButton(QelButton::Default, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "plain", parent));
-        buttons.append(new QelButton(QelButton::Primary, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "primary", parent));
-        buttons.append(new QelButton(QelButton::Success, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "success", parent));
-        buttons.append(new QelButton(QelButton::Info, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "info", parent));
-        buttons.append(new QelButton(QelButton::Warning, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "warning", parent));
-        buttons.append(new QelButton(QelButton::Danger, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "danger", parent));
+        buttons.append(new QelButton(QelButton::Default, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "plain", parent));
+        buttons.append(new QelButton(QelButton::Primary, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "primary", parent));
+        buttons.append(new QelButton(QelButton::Success, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "success", parent));
+        buttons.append(new QelButton(QelButton::Info, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "info", parent));
+        buttons.append(new QelButton(QelButton::Warning, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "warning", parent));
+        buttons.append(new QelButton(QelButton::Danger, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "danger", parent));
         return buttons;
     }
 
@@ -246,9 +245,9 @@ private:
         layout->addWidget(title);
 
         QHBoxLayout *demoRow = new QHBoxLayout();
-        QelButton *showPopupButton = new QelButton(QelButton::Primary, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Show Popup", this);
-        QelButton *fadeButton = new QelButton(QelButton::Success, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Fade In/Out", this);
-        QelButton *pressEffectButton = new QelButton(QelButton::Warning, QelButton::Medium, false, true, false, false, QelButton::Button, QIcon(), "Press Feedback", this);
+        QelButton *showPopupButton = new QelButton(QelButton::Primary, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Show Popup", this);
+        QelButton *fadeButton = new QelButton(QelButton::Success, QelButton::Default, true, false, false, false, QelButton::Button, QIcon(), "Fade In/Out", this);
+        QelButton *pressEffectButton = new QelButton(QelButton::Warning, QelButton::Default, false, true, false, false, QelButton::Button, QIcon(), "Press Feedback", this);
 
         animationTarget_ = new QLabel("Animation Target", this);
         animationTarget_->setMinimumWidth(140);

--- a/QelButton/QelButtonTester.h
+++ b/QelButton/QelButtonTester.h
@@ -6,13 +6,8 @@
 #include <QFrame>
 #include <QHBoxLayout>
 #include <QLabel>
-#include <QTimer>
 #include <QVBoxLayout>
 #include <QWidget>
-
-#include "../QelAnimationHelper/QelAnimationHelper.h"
-#include "../QelIcon/QelIcon.h"
-#include "../QelPopupManager/QelPopupManager.h"
 
 using namespace qel;
 
@@ -22,185 +17,107 @@ public:
         : QWidget(parent)
     {
         QVBoxLayout *mainLayout = new QVBoxLayout(this);
+        mainLayout->setSpacing(16);
 
-        QList<QelButton *> defaultButtons;
-        defaultButtons.append(new QelButton(QelButton::Default, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Default", this));
-        defaultButtons.append(new QelButton(QelButton::Primary, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Primary", this));
-        defaultButtons.append(new QelButton(QelButton::Success, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Success", this));
-        defaultButtons.append(new QelButton(QelButton::Info, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Info", this));
-        defaultButtons.append(new QelButton(QelButton::Warning, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Warning", this));
-        defaultButtons.append(new QelButton(QelButton::Danger, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Danger", this));
-        addButtonRow(mainLayout, "Default Buttons", defaultButtons);
+        QLabel *linkTitle = new QLabel("Link Button", this);
+        linkTitle->setStyleSheet("font-size: 28px; font-weight: 700; color: #303133;");
+        mainLayout->addWidget(linkTitle);
 
-        QList<QelButton *> plainButtons;
-        plainButtons.append(new QelButton(QelButton::Default, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Plain", this));
-        plainButtons.append(new QelButton(QelButton::Primary, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Primary", this));
-        plainButtons.append(new QelButton(QelButton::Success, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Success", this));
-        plainButtons.append(new QelButton(QelButton::Info, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Info", this));
-        plainButtons.append(new QelButton(QelButton::Warning, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Warning", this));
-        plainButtons.append(new QelButton(QelButton::Danger, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Danger", this));
-        addButtonRow(mainLayout, "Plain Buttons", plainButtons);
+        QFrame *linkCard = createCard();
+        QVBoxLayout *linkLayout = new QVBoxLayout(linkCard);
+        linkLayout->addWidget(makeSectionLabel("Basic link button"));
 
-        QList<QelButton *> roundButtons;
-        roundButtons.append(new QelButton(QelButton::Primary, QelButton::Medium, false, true, false, false, QelButton::Button, QIcon(), "Primary", this));
-        roundButtons.append(new QelButton(QelButton::Success, QelButton::Medium, false, true, false, false, QelButton::Button, QIcon(), "Success", this));
-        roundButtons.append(new QelButton(QelButton::Info, QelButton::Medium, false, true, false, false, QelButton::Button, QIcon(), "Info", this));
-        roundButtons.append(new QelButton(QelButton::Warning, QelButton::Medium, false, true, false, false, QelButton::Button, QIcon(), "Warning", this));
-        roundButtons.append(new QelButton(QelButton::Danger, QelButton::Medium, false, true, false, false, QelButton::Button, QIcon(), "Danger", this));
-        addButtonRow(mainLayout, "Round Buttons", roundButtons);
+        QList<QelButton *> basicLinks = makeSemanticButtons(this);
+        for (QelButton *button : basicLinks) {
+            button->setLinkMode(true);
+        }
+        linkLayout->addLayout(makeButtonRow(basicLinks));
 
-        QList<QelButton *> iconButtons;
-        iconButtons.append(new QelButton(QelButton::Default, QelButton::Small, false, true, true, false, QelButton::Button, QelIcon(QelIcon::Search, 16, Qt::gray), "", this));
-        iconButtons.append(new QelButton(QelButton::Primary, QelButton::Small, false, true, true, false, QelButton::Button, QelIcon(QelIcon::Edit, 16, Qt::white), "", this));
-        iconButtons.append(new QelButton(QelButton::Success, QelButton::Small, false, true, true, false, QelButton::Button, QelIcon(QelIcon::Check, 16, Qt::white), "", this));
-        iconButtons.append(new QelButton(QelButton::Info, QelButton::Small, false, true, true, false, QelButton::Button, QelIcon(QelIcon::Envelope, 16, Qt::white), "", this));
-        iconButtons.append(new QelButton(QelButton::Warning, QelButton::Small, false, true, true, false, QelButton::Button, QelIcon(QelIcon::Star, 16, Qt::white), "", this));
-        iconButtons.append(new QelButton(QelButton::Danger, QelButton::Small, false, true, true, false, QelButton::Button, QelIcon(QelIcon::Trash, 16, Qt::white), "", this));
-        addButtonRow(mainLayout, "Icon Buttons", iconButtons);
-
-        QList<QelButton *> disabledButtons;
-        disabledButtons.append(new QelButton(QelButton::Default, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Default", this));
-        disabledButtons.append(new QelButton(QelButton::Primary, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Primary", this));
-        disabledButtons.append(new QelButton(QelButton::Success, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Success", this));
-        disabledButtons.append(new QelButton(QelButton::Info, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Info", this));
-        disabledButtons.append(new QelButton(QelButton::Warning, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Warning", this));
-        disabledButtons.append(new QelButton(QelButton::Danger, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Danger", this));
-        for (QelButton *button : disabledButtons) {
+        linkLayout->addWidget(makeSectionLabel("Disabled link button"));
+        QList<QelButton *> disabledLinks = makeSemanticButtons(this);
+        for (QelButton *button : disabledLinks) {
+            button->setLinkMode(true);
             button->setDisabled(true);
         }
-        addButtonRow(mainLayout, "Disabled Buttons", disabledButtons);
+        linkLayout->addLayout(makeButtonRow(disabledLinks));
+        mainLayout->addWidget(linkCard);
 
-        QList<QelButton *> disabledPlainButtons;
-        disabledPlainButtons.append(new QelButton(QelButton::Default, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Default", this));
-        disabledPlainButtons.append(new QelButton(QelButton::Primary, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Primary", this));
-        disabledPlainButtons.append(new QelButton(QelButton::Success, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Success", this));
-        disabledPlainButtons.append(new QelButton(QelButton::Info, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Info", this));
-        disabledPlainButtons.append(new QelButton(QelButton::Warning, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Warning", this));
-        disabledPlainButtons.append(new QelButton(QelButton::Danger, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Danger", this));
-        for (QelButton *button : disabledPlainButtons) {
-            button->setDisabled(true);
+        QLabel *textTitle = new QLabel("Text Button", this);
+        textTitle->setStyleSheet("font-size: 28px; font-weight: 700; color: #303133;");
+        mainLayout->addWidget(textTitle);
+
+        QLabel *textDesc = new QLabel("Buttons without border and background.", this);
+        textDesc->setStyleSheet("font-size: 18px; color: #606266;");
+        mainLayout->addWidget(textDesc);
+
+        QFrame *textCard = createCard();
+        QVBoxLayout *textLayout = new QVBoxLayout(textCard);
+
+        textLayout->addWidget(makeSectionLabel("Basic text button"));
+        QList<QelButton *> basicTexts = makeSemanticButtons(this);
+        for (QelButton *button : basicTexts) {
+            button->setTextMode(true);
         }
-        addButtonRow(mainLayout, "Disabled Plain Buttons", disabledPlainButtons);
+        textLayout->addLayout(makeButtonRow(basicTexts));
 
-        QList<QelButton *> textButtons;
-        textButtons.append(new QelButton(QelButton::Default, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Default Text", this));
-        textButtons.append(new QelButton(QelButton::Primary, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Primary Text", this));
-        textButtons.append(new QelButton(QelButton::Success, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Success Text", this));
-        for (QelButton *button : textButtons) {
+        textLayout->addWidget(makeSectionLabel("Background color always on"));
+        QList<QelButton *> bgTexts = makeSemanticButtons(this);
+        for (QelButton *button : bgTexts) {
             button->setTextMode(true);
             button->setBg(true);
         }
-        addButtonRow(mainLayout, "Text Buttons", textButtons);
+        textLayout->addLayout(makeButtonRow(bgTexts));
 
-        QList<QelButton *> linkButtons;
-        linkButtons.append(new QelButton(QelButton::Default, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Default Link", this));
-        linkButtons.append(new QelButton(QelButton::Primary, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Primary Link", this));
-        linkButtons.append(new QelButton(QelButton::Danger, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Danger Link", this));
-        for (QelButton *button : linkButtons) {
-            button->setLinkMode(true);
+        textLayout->addWidget(makeSectionLabel("Disabled text button"));
+        QList<QelButton *> disabledTexts = makeSemanticButtons(this);
+        for (QelButton *button : disabledTexts) {
+            button->setTextMode(true);
+            button->setDisabled(true);
         }
-        addButtonRow(mainLayout, "Link Buttons", linkButtons);
+        textLayout->addLayout(makeButtonRow(disabledTexts));
 
-        QList<QelButton *> customColorButtons;
-        QelButton *customTeal = new QelButton(QelButton::Primary, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Custom #13c2c2", this);
-        customTeal->setColor("#13c2c2");
-        QelButton *customPurple = new QelButton(QelButton::Primary, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Custom #722ed1", this);
-        customPurple->setColor("#722ed1");
-        customColorButtons.append(customTeal);
-        customColorButtons.append(customPurple);
-        addButtonRow(mainLayout, "Custom Color Buttons", customColorButtons);
-
-        QList<QelButton *> sizeButtons;
-        sizeButtons.append(new QelButton(QelButton::Primary, QelButton::Large, false, false, false, false, QelButton::Button, QIcon(), "Large", this));
-        sizeButtons.append(new QelButton(QelButton::Primary, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Medium", this));
-        sizeButtons.append(new QelButton(QelButton::Primary, QelButton::Small, false, false, false, false, QelButton::Button, QIcon(), "Small", this));
-        sizeButtons.append(new QelButton(QelButton::Primary, QelButton::Mini, false, false, false, false, QelButton::Button, QIcon(), "Mini", this));
-        addButtonRow(mainLayout, "Button Sizes", sizeButtons);
-
-        addPopupAndAnimationDemo(mainLayout);
+        mainLayout->addWidget(textCard);
+        mainLayout->addStretch();
         setLayout(mainLayout);
+        setStyleSheet("QWidget { background: #f5f7fa; }");
     }
 
 private:
-    QWidget *animationTarget_ = nullptr;
-
-    void addButtonRow(QVBoxLayout *layout, const QString &title, const QList<QelButton *> &buttons)
+    QFrame *createCard()
     {
-        QHBoxLayout *rowLayout = new QHBoxLayout();
-
-        QLabel *label = new QLabel(title);
-        rowLayout->addWidget(label);
-
-        for (QelButton *button : buttons) {
-            rowLayout->addWidget(button);
-        }
-
-        layout->addLayout(rowLayout);
+        QFrame *card = new QFrame(this);
+        card->setStyleSheet("QFrame { background: #ffffff; border: 1px solid #dcdfe6; border-radius: 4px; }");
+        return card;
     }
 
-    void addPopupAndAnimationDemo(QVBoxLayout *layout)
+    QLabel *makeSectionLabel(const QString &text)
     {
-        QLabel *title = new QLabel("Popup && Animation Demo");
-        layout->addWidget(title);
+        QLabel *label = new QLabel(text, this);
+        label->setStyleSheet("font-size: 16px; color: #303133; margin: 8px 0;");
+        return label;
+    }
 
-        QHBoxLayout *demoRow = new QHBoxLayout();
-        QelButton *showPopupButton = new QelButton(QelButton::Primary, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Show Popup", this);
-        QelButton *fadeButton = new QelButton(QelButton::Success, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Fade In/Out", this);
-        QelButton *pressEffectButton = new QelButton(QelButton::Warning, QelButton::Medium, false, true, false, false, QelButton::Button, QIcon(), "Press Feedback", this);
+    QList<QelButton *> makeSemanticButtons(QWidget *parent)
+    {
+        QList<QelButton *> buttons;
+        buttons.append(new QelButton(QelButton::Default, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "plain", parent));
+        buttons.append(new QelButton(QelButton::Primary, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "primary", parent));
+        buttons.append(new QelButton(QelButton::Success, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "success", parent));
+        buttons.append(new QelButton(QelButton::Info, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "info", parent));
+        buttons.append(new QelButton(QelButton::Warning, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "warning", parent));
+        buttons.append(new QelButton(QelButton::Danger, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "danger", parent));
+        return buttons;
+    }
 
-        animationTarget_ = new QLabel("Animation Target", this);
-        animationTarget_->setMinimumWidth(140);
-        animationTarget_->setStyleSheet("QLabel{background:#f5f7fa;border:1px solid #dcdfe6;padding:6px;border-radius:4px;}");
-
-        demoRow->addWidget(showPopupButton);
-        demoRow->addWidget(fadeButton);
-        demoRow->addWidget(pressEffectButton);
-        demoRow->addWidget(animationTarget_);
-        demoRow->addStretch();
-        layout->addLayout(demoRow);
-
-        connect(showPopupButton, &QelButton::clicked, this, [this, showPopupButton]() {
-            QFrame *popup = new QFrame(nullptr, Qt::ToolTip);
-            popup->setAttribute(Qt::WA_DeleteOnClose, true);
-            popup->setStyleSheet("QFrame{background:#ffffff;border:1px solid #dcdfe6;border-radius:4px;} QLabel{padding:6px;color:#606266;}");
-
-            QVBoxLayout *popupLayout = new QVBoxLayout(popup);
-            popupLayout->setContentsMargins(8, 8, 8, 8);
-            popupLayout->addWidget(new QLabel("QelPopupManager demo", popup));
-            popupLayout->addWidget(new QLabel("- auto placement clamp", popup));
-            popupLayout->addWidget(new QLabel("- zIndex allocate", popup));
-
-            popup->resize(200, 90);
-
-            const QPoint pos = QelPopupManager::computePopupPosition(showPopupButton, popup->size(), PopupPlacement::Bottom);
-            popup->move(pos);
-            popup->raise();
-            popup->setWindowTitle(QString::number(QelPopupManager::acquireZIndex(PopupType::Popover)));
-            QelPopupManager::registerPopup(popup, {PopupType::Popover, true, true, false});
-            QelPopupManager::handleScreenBoundary(popup);
-
-            popup->show();
-            QelAnimationHelper::fadeIn(popup, 180);
-            QTimer::singleShot(1600, popup, [popup]() {
-                QelAnimationHelper::fadeOut(popup, 160);
-            });
-        });
-
-        connect(fadeButton, &QelButton::clicked, this, [this]() {
-            if (animationTarget_ == nullptr) {
-                return;
-            }
-
-            if (animationTarget_->isVisible()) {
-                QelAnimationHelper::fadeOut(animationTarget_, 140);
-            } else {
-                QelAnimationHelper::fadeIn(animationTarget_, 160);
-            }
-        });
-
-        connect(pressEffectButton, &QelButton::clicked, this, [pressEffectButton]() {
-            QelAnimationHelper::pressFeedback(pressEffectButton, 110);
-        });
+    QHBoxLayout *makeButtonRow(const QList<QelButton *> &buttons)
+    {
+        QHBoxLayout *row = new QHBoxLayout();
+        row->setSpacing(12);
+        for (QelButton *button : buttons) {
+            row->addWidget(button);
+        }
+        row->addStretch();
+        return row;
     }
 };
 

--- a/QelButton/QelButtonTester.h
+++ b/QelButton/QelButtonTester.h
@@ -24,68 +24,68 @@ public:
         QVBoxLayout *mainLayout = new QVBoxLayout(this);
 
         QList<QelButton *> defaultButtons;
-        defaultButtons.append(new QelButton(QelButton::Default, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Default", this));
-        defaultButtons.append(new QelButton(QelButton::Primary, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Primary", this));
-        defaultButtons.append(new QelButton(QelButton::Success, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Success", this));
-        defaultButtons.append(new QelButton(QelButton::Info, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Info", this));
-        defaultButtons.append(new QelButton(QelButton::Warning, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Warning", this));
-        defaultButtons.append(new QelButton(QelButton::Danger, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Danger", this));
+        defaultButtons.append(new QelButton(QelButton::Default, QelButton::DefaultSize, false, false, false, false, QelButton::Button, QIcon(), "Default", this));
+        defaultButtons.append(new QelButton(QelButton::Primary, QelButton::DefaultSize, false, false, false, false, QelButton::Button, QIcon(), "Primary", this));
+        defaultButtons.append(new QelButton(QelButton::Success, QelButton::DefaultSize, false, false, false, false, QelButton::Button, QIcon(), "Success", this));
+        defaultButtons.append(new QelButton(QelButton::Info, QelButton::DefaultSize, false, false, false, false, QelButton::Button, QIcon(), "Info", this));
+        defaultButtons.append(new QelButton(QelButton::Warning, QelButton::DefaultSize, false, false, false, false, QelButton::Button, QIcon(), "Warning", this));
+        defaultButtons.append(new QelButton(QelButton::Danger, QelButton::DefaultSize, false, false, false, false, QelButton::Button, QIcon(), "Danger", this));
         addButtonRow(mainLayout, "Default Buttons", defaultButtons);
 
         QList<QelButton *> plainButtons;
-        plainButtons.append(new QelButton(QelButton::Default, QelButton::Default, true, false, false, false, QelButton::Button, QIcon(), "Plain", this));
-        plainButtons.append(new QelButton(QelButton::Primary, QelButton::Default, true, false, false, false, QelButton::Button, QIcon(), "Primary", this));
-        plainButtons.append(new QelButton(QelButton::Success, QelButton::Default, true, false, false, false, QelButton::Button, QIcon(), "Success", this));
-        plainButtons.append(new QelButton(QelButton::Info, QelButton::Default, true, false, false, false, QelButton::Button, QIcon(), "Info", this));
-        plainButtons.append(new QelButton(QelButton::Warning, QelButton::Default, true, false, false, false, QelButton::Button, QIcon(), "Warning", this));
-        plainButtons.append(new QelButton(QelButton::Danger, QelButton::Default, true, false, false, false, QelButton::Button, QIcon(), "Danger", this));
+        plainButtons.append(new QelButton(QelButton::Default, QelButton::DefaultSize, true, false, false, false, QelButton::Button, QIcon(), "Plain", this));
+        plainButtons.append(new QelButton(QelButton::Primary, QelButton::DefaultSize, true, false, false, false, QelButton::Button, QIcon(), "Primary", this));
+        plainButtons.append(new QelButton(QelButton::Success, QelButton::DefaultSize, true, false, false, false, QelButton::Button, QIcon(), "Success", this));
+        plainButtons.append(new QelButton(QelButton::Info, QelButton::DefaultSize, true, false, false, false, QelButton::Button, QIcon(), "Info", this));
+        plainButtons.append(new QelButton(QelButton::Warning, QelButton::DefaultSize, true, false, false, false, QelButton::Button, QIcon(), "Warning", this));
+        plainButtons.append(new QelButton(QelButton::Danger, QelButton::DefaultSize, true, false, false, false, QelButton::Button, QIcon(), "Danger", this));
         addButtonRow(mainLayout, "Plain Buttons", plainButtons);
 
         QList<QelButton *> roundButtons;
-        roundButtons.append(new QelButton(QelButton::Primary, QelButton::Default, false, true, false, false, QelButton::Button, QIcon(), "Primary", this));
-        roundButtons.append(new QelButton(QelButton::Success, QelButton::Default, false, true, false, false, QelButton::Button, QIcon(), "Success", this));
-        roundButtons.append(new QelButton(QelButton::Info, QelButton::Default, false, true, false, false, QelButton::Button, QIcon(), "Info", this));
-        roundButtons.append(new QelButton(QelButton::Warning, QelButton::Default, false, true, false, false, QelButton::Button, QIcon(), "Warning", this));
-        roundButtons.append(new QelButton(QelButton::Danger, QelButton::Default, false, true, false, false, QelButton::Button, QIcon(), "Danger", this));
+        roundButtons.append(new QelButton(QelButton::Primary, QelButton::DefaultSize, false, true, false, false, QelButton::Button, QIcon(), "Primary", this));
+        roundButtons.append(new QelButton(QelButton::Success, QelButton::DefaultSize, false, true, false, false, QelButton::Button, QIcon(), "Success", this));
+        roundButtons.append(new QelButton(QelButton::Info, QelButton::DefaultSize, false, true, false, false, QelButton::Button, QIcon(), "Info", this));
+        roundButtons.append(new QelButton(QelButton::Warning, QelButton::DefaultSize, false, true, false, false, QelButton::Button, QIcon(), "Warning", this));
+        roundButtons.append(new QelButton(QelButton::Danger, QelButton::DefaultSize, false, true, false, false, QelButton::Button, QIcon(), "Danger", this));
         addButtonRow(mainLayout, "Round Buttons", roundButtons);
 
         QList<QelButton *> iconButtons;
-        iconButtons.append(new QelButton(QelButton::Default, QelButton::Small, false, true, true, false, QelButton::Button, QelIcon(QelIcon::Search, 16, Qt::gray), "", this));
-        iconButtons.append(new QelButton(QelButton::Primary, QelButton::Small, false, true, true, false, QelButton::Button, QelIcon(QelIcon::Edit, 16, Qt::white), "", this));
-        iconButtons.append(new QelButton(QelButton::Success, QelButton::Small, false, true, true, false, QelButton::Button, QelIcon(QelIcon::Check, 16, Qt::white), "", this));
-        iconButtons.append(new QelButton(QelButton::Info, QelButton::Small, false, true, true, false, QelButton::Button, QelIcon(QelIcon::Envelope, 16, Qt::white), "", this));
-        iconButtons.append(new QelButton(QelButton::Warning, QelButton::Small, false, true, true, false, QelButton::Button, QelIcon(QelIcon::Star, 16, Qt::white), "", this));
-        iconButtons.append(new QelButton(QelButton::Danger, QelButton::Small, false, true, true, false, QelButton::Button, QelIcon(QelIcon::Trash, 16, Qt::white), "", this));
+        iconButtons.append(new QelButton(QelButton::Default, QelButton::SmallSize, false, true, true, false, QelButton::Button, QelIcon(QelIcon::Search, 16, Qt::gray), "", this));
+        iconButtons.append(new QelButton(QelButton::Primary, QelButton::SmallSize, false, true, true, false, QelButton::Button, QelIcon(QelIcon::Edit, 16, Qt::white), "", this));
+        iconButtons.append(new QelButton(QelButton::Success, QelButton::SmallSize, false, true, true, false, QelButton::Button, QelIcon(QelIcon::Check, 16, Qt::white), "", this));
+        iconButtons.append(new QelButton(QelButton::Info, QelButton::SmallSize, false, true, true, false, QelButton::Button, QelIcon(QelIcon::Envelope, 16, Qt::white), "", this));
+        iconButtons.append(new QelButton(QelButton::Warning, QelButton::SmallSize, false, true, true, false, QelButton::Button, QelIcon(QelIcon::Star, 16, Qt::white), "", this));
+        iconButtons.append(new QelButton(QelButton::Danger, QelButton::SmallSize, false, true, true, false, QelButton::Button, QelIcon(QelIcon::Trash, 16, Qt::white), "", this));
         addButtonRow(mainLayout, "Icon Buttons", iconButtons);
 
         QList<QelButton *> disabledButtons;
-        disabledButtons.append(new QelButton(QelButton::Default, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Default", this));
-        disabledButtons.append(new QelButton(QelButton::Primary, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Primary", this));
-        disabledButtons.append(new QelButton(QelButton::Success, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Success", this));
-        disabledButtons.append(new QelButton(QelButton::Info, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Info", this));
-        disabledButtons.append(new QelButton(QelButton::Warning, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Warning", this));
-        disabledButtons.append(new QelButton(QelButton::Danger, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Danger", this));
+        disabledButtons.append(new QelButton(QelButton::Default, QelButton::DefaultSize, false, false, false, false, QelButton::Button, QIcon(), "Default", this));
+        disabledButtons.append(new QelButton(QelButton::Primary, QelButton::DefaultSize, false, false, false, false, QelButton::Button, QIcon(), "Primary", this));
+        disabledButtons.append(new QelButton(QelButton::Success, QelButton::DefaultSize, false, false, false, false, QelButton::Button, QIcon(), "Success", this));
+        disabledButtons.append(new QelButton(QelButton::Info, QelButton::DefaultSize, false, false, false, false, QelButton::Button, QIcon(), "Info", this));
+        disabledButtons.append(new QelButton(QelButton::Warning, QelButton::DefaultSize, false, false, false, false, QelButton::Button, QIcon(), "Warning", this));
+        disabledButtons.append(new QelButton(QelButton::Danger, QelButton::DefaultSize, false, false, false, false, QelButton::Button, QIcon(), "Danger", this));
         for (QelButton *button : disabledButtons) {
             button->setDisabled(true);
         }
         addButtonRow(mainLayout, "Disabled Buttons", disabledButtons);
 
         QList<QelButton *> disabledPlainButtons;
-        disabledPlainButtons.append(new QelButton(QelButton::Default, QelButton::Default, true, false, false, false, QelButton::Button, QIcon(), "Default", this));
-        disabledPlainButtons.append(new QelButton(QelButton::Primary, QelButton::Default, true, false, false, false, QelButton::Button, QIcon(), "Primary", this));
-        disabledPlainButtons.append(new QelButton(QelButton::Success, QelButton::Default, true, false, false, false, QelButton::Button, QIcon(), "Success", this));
-        disabledPlainButtons.append(new QelButton(QelButton::Info, QelButton::Default, true, false, false, false, QelButton::Button, QIcon(), "Info", this));
-        disabledPlainButtons.append(new QelButton(QelButton::Warning, QelButton::Default, true, false, false, false, QelButton::Button, QIcon(), "Warning", this));
-        disabledPlainButtons.append(new QelButton(QelButton::Danger, QelButton::Default, true, false, false, false, QelButton::Button, QIcon(), "Danger", this));
+        disabledPlainButtons.append(new QelButton(QelButton::Default, QelButton::DefaultSize, true, false, false, false, QelButton::Button, QIcon(), "Default", this));
+        disabledPlainButtons.append(new QelButton(QelButton::Primary, QelButton::DefaultSize, true, false, false, false, QelButton::Button, QIcon(), "Primary", this));
+        disabledPlainButtons.append(new QelButton(QelButton::Success, QelButton::DefaultSize, true, false, false, false, QelButton::Button, QIcon(), "Success", this));
+        disabledPlainButtons.append(new QelButton(QelButton::Info, QelButton::DefaultSize, true, false, false, false, QelButton::Button, QIcon(), "Info", this));
+        disabledPlainButtons.append(new QelButton(QelButton::Warning, QelButton::DefaultSize, true, false, false, false, QelButton::Button, QIcon(), "Warning", this));
+        disabledPlainButtons.append(new QelButton(QelButton::Danger, QelButton::DefaultSize, true, false, false, false, QelButton::Button, QIcon(), "Danger", this));
         for (QelButton *button : disabledPlainButtons) {
             button->setDisabled(true);
         }
         addButtonRow(mainLayout, "Disabled Plain Buttons", disabledPlainButtons);
 
         QList<QelButton *> textButtons;
-        textButtons.append(new QelButton(QelButton::Default, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Default Text", this));
-        textButtons.append(new QelButton(QelButton::Primary, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Primary Text", this));
-        textButtons.append(new QelButton(QelButton::Success, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Success Text", this));
+        textButtons.append(new QelButton(QelButton::Default, QelButton::DefaultSize, false, false, false, false, QelButton::Button, QIcon(), "Default Text", this));
+        textButtons.append(new QelButton(QelButton::Primary, QelButton::DefaultSize, false, false, false, false, QelButton::Button, QIcon(), "Primary Text", this));
+        textButtons.append(new QelButton(QelButton::Success, QelButton::DefaultSize, false, false, false, false, QelButton::Button, QIcon(), "Success Text", this));
         for (QelButton *button : textButtons) {
             button->setTextMode(true);
             button->setBg(true);
@@ -93,27 +93,27 @@ public:
         addButtonRow(mainLayout, "Text Buttons", textButtons);
 
         QList<QelButton *> linkButtons;
-        linkButtons.append(new QelButton(QelButton::Default, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Default Link", this));
-        linkButtons.append(new QelButton(QelButton::Primary, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Primary Link", this));
-        linkButtons.append(new QelButton(QelButton::Danger, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Danger Link", this));
+        linkButtons.append(new QelButton(QelButton::Default, QelButton::DefaultSize, false, false, false, false, QelButton::Button, QIcon(), "Default Link", this));
+        linkButtons.append(new QelButton(QelButton::Primary, QelButton::DefaultSize, false, false, false, false, QelButton::Button, QIcon(), "Primary Link", this));
+        linkButtons.append(new QelButton(QelButton::Danger, QelButton::DefaultSize, false, false, false, false, QelButton::Button, QIcon(), "Danger Link", this));
         for (QelButton *button : linkButtons) {
             button->setLinkMode(true);
         }
         addButtonRow(mainLayout, "Link Buttons", linkButtons);
 
         QList<QelButton *> customColorButtons;
-        QelButton *customTeal = new QelButton(QelButton::Primary, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Custom #13c2c2", this);
+        QelButton *customTeal = new QelButton(QelButton::Primary, QelButton::DefaultSize, false, false, false, false, QelButton::Button, QIcon(), "Custom #13c2c2", this);
         customTeal->setColor("#13c2c2");
-        QelButton *customPurple = new QelButton(QelButton::Primary, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Custom #722ed1", this);
+        QelButton *customPurple = new QelButton(QelButton::Primary, QelButton::DefaultSize, false, false, false, false, QelButton::Button, QIcon(), "Custom #722ed1", this);
         customPurple->setColor("#722ed1");
         customColorButtons.append(customTeal);
         customColorButtons.append(customPurple);
         addButtonRow(mainLayout, "Custom Color Buttons", customColorButtons);
 
         QList<QelButton *> sizeButtons;
-        sizeButtons.append(new QelButton(QelButton::Primary, QelButton::Large, false, false, false, false, QelButton::Button, QIcon(), "Large", this));
-        sizeButtons.append(new QelButton(QelButton::Primary, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Default", this));
-        sizeButtons.append(new QelButton(QelButton::Primary, QelButton::Small, false, false, false, false, QelButton::Button, QIcon(), "Small", this));
+        sizeButtons.append(new QelButton(QelButton::Primary, QelButton::LargeSize, false, false, false, false, QelButton::Button, QIcon(), "Large", this));
+        sizeButtons.append(new QelButton(QelButton::Primary, QelButton::DefaultSize, false, false, false, false, QelButton::Button, QIcon(), "Default", this));
+        sizeButtons.append(new QelButton(QelButton::Primary, QelButton::SmallSize, false, false, false, false, QelButton::Button, QIcon(), "Small", this));
         addButtonRow(mainLayout, "Button Sizes", sizeButtons);
 
         addElementPlusLinkTextShowcase(mainLayout);
@@ -219,12 +219,12 @@ private:
     QList<QelButton *> makeElementSemanticButtons(QWidget *parent)
     {
         QList<QelButton *> buttons;
-        buttons.append(new QelButton(QelButton::Default, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "plain", parent));
-        buttons.append(new QelButton(QelButton::Primary, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "primary", parent));
-        buttons.append(new QelButton(QelButton::Success, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "success", parent));
-        buttons.append(new QelButton(QelButton::Info, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "info", parent));
-        buttons.append(new QelButton(QelButton::Warning, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "warning", parent));
-        buttons.append(new QelButton(QelButton::Danger, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "danger", parent));
+        buttons.append(new QelButton(QelButton::Default, QelButton::DefaultSize, false, false, false, false, QelButton::Button, QIcon(), "plain", parent));
+        buttons.append(new QelButton(QelButton::Primary, QelButton::DefaultSize, false, false, false, false, QelButton::Button, QIcon(), "primary", parent));
+        buttons.append(new QelButton(QelButton::Success, QelButton::DefaultSize, false, false, false, false, QelButton::Button, QIcon(), "success", parent));
+        buttons.append(new QelButton(QelButton::Info, QelButton::DefaultSize, false, false, false, false, QelButton::Button, QIcon(), "info", parent));
+        buttons.append(new QelButton(QelButton::Warning, QelButton::DefaultSize, false, false, false, false, QelButton::Button, QIcon(), "warning", parent));
+        buttons.append(new QelButton(QelButton::Danger, QelButton::DefaultSize, false, false, false, false, QelButton::Button, QIcon(), "danger", parent));
         return buttons;
     }
 
@@ -245,9 +245,9 @@ private:
         layout->addWidget(title);
 
         QHBoxLayout *demoRow = new QHBoxLayout();
-        QelButton *showPopupButton = new QelButton(QelButton::Primary, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Show Popup", this);
-        QelButton *fadeButton = new QelButton(QelButton::Success, QelButton::Default, true, false, false, false, QelButton::Button, QIcon(), "Fade In/Out", this);
-        QelButton *pressEffectButton = new QelButton(QelButton::Warning, QelButton::Default, false, true, false, false, QelButton::Button, QIcon(), "Press Feedback", this);
+        QelButton *showPopupButton = new QelButton(QelButton::Primary, QelButton::DefaultSize, false, false, false, false, QelButton::Button, QIcon(), "Show Popup", this);
+        QelButton *fadeButton = new QelButton(QelButton::Success, QelButton::DefaultSize, true, false, false, false, QelButton::Button, QIcon(), "Fade In/Out", this);
+        QelButton *pressEffectButton = new QelButton(QelButton::Warning, QelButton::DefaultSize, false, true, false, false, QelButton::Button, QIcon(), "Press Feedback", this);
 
         animationTarget_ = new QLabel("Animation Target", this);
         animationTarget_->setMinimumWidth(140);

--- a/QelButton/QelButtonTester.h
+++ b/QelButton/QelButtonTester.h
@@ -6,8 +6,13 @@
 #include <QFrame>
 #include <QHBoxLayout>
 #include <QLabel>
+#include <QTimer>
 #include <QVBoxLayout>
 #include <QWidget>
+
+#include "../QelAnimationHelper/QelAnimationHelper.h"
+#include "../QelIcon/QelIcon.h"
+#include "../QelPopupManager/QelPopupManager.h"
 
 using namespace qel;
 
@@ -17,87 +22,202 @@ public:
         : QWidget(parent)
     {
         QVBoxLayout *mainLayout = new QVBoxLayout(this);
-        mainLayout->setSpacing(16);
 
+        QList<QelButton *> defaultButtons;
+        defaultButtons.append(new QelButton(QelButton::Default, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Default", this));
+        defaultButtons.append(new QelButton(QelButton::Primary, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Primary", this));
+        defaultButtons.append(new QelButton(QelButton::Success, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Success", this));
+        defaultButtons.append(new QelButton(QelButton::Info, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Info", this));
+        defaultButtons.append(new QelButton(QelButton::Warning, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Warning", this));
+        defaultButtons.append(new QelButton(QelButton::Danger, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Danger", this));
+        addButtonRow(mainLayout, "Default Buttons", defaultButtons);
+
+        QList<QelButton *> plainButtons;
+        plainButtons.append(new QelButton(QelButton::Default, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Plain", this));
+        plainButtons.append(new QelButton(QelButton::Primary, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Primary", this));
+        plainButtons.append(new QelButton(QelButton::Success, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Success", this));
+        plainButtons.append(new QelButton(QelButton::Info, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Info", this));
+        plainButtons.append(new QelButton(QelButton::Warning, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Warning", this));
+        plainButtons.append(new QelButton(QelButton::Danger, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Danger", this));
+        addButtonRow(mainLayout, "Plain Buttons", plainButtons);
+
+        QList<QelButton *> roundButtons;
+        roundButtons.append(new QelButton(QelButton::Primary, QelButton::Medium, false, true, false, false, QelButton::Button, QIcon(), "Primary", this));
+        roundButtons.append(new QelButton(QelButton::Success, QelButton::Medium, false, true, false, false, QelButton::Button, QIcon(), "Success", this));
+        roundButtons.append(new QelButton(QelButton::Info, QelButton::Medium, false, true, false, false, QelButton::Button, QIcon(), "Info", this));
+        roundButtons.append(new QelButton(QelButton::Warning, QelButton::Medium, false, true, false, false, QelButton::Button, QIcon(), "Warning", this));
+        roundButtons.append(new QelButton(QelButton::Danger, QelButton::Medium, false, true, false, false, QelButton::Button, QIcon(), "Danger", this));
+        addButtonRow(mainLayout, "Round Buttons", roundButtons);
+
+        QList<QelButton *> iconButtons;
+        iconButtons.append(new QelButton(QelButton::Default, QelButton::Small, false, true, true, false, QelButton::Button, QelIcon(QelIcon::Search, 16, Qt::gray), "", this));
+        iconButtons.append(new QelButton(QelButton::Primary, QelButton::Small, false, true, true, false, QelButton::Button, QelIcon(QelIcon::Edit, 16, Qt::white), "", this));
+        iconButtons.append(new QelButton(QelButton::Success, QelButton::Small, false, true, true, false, QelButton::Button, QelIcon(QelIcon::Check, 16, Qt::white), "", this));
+        iconButtons.append(new QelButton(QelButton::Info, QelButton::Small, false, true, true, false, QelButton::Button, QelIcon(QelIcon::Envelope, 16, Qt::white), "", this));
+        iconButtons.append(new QelButton(QelButton::Warning, QelButton::Small, false, true, true, false, QelButton::Button, QelIcon(QelIcon::Star, 16, Qt::white), "", this));
+        iconButtons.append(new QelButton(QelButton::Danger, QelButton::Small, false, true, true, false, QelButton::Button, QelIcon(QelIcon::Trash, 16, Qt::white), "", this));
+        addButtonRow(mainLayout, "Icon Buttons", iconButtons);
+
+        QList<QelButton *> disabledButtons;
+        disabledButtons.append(new QelButton(QelButton::Default, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Default", this));
+        disabledButtons.append(new QelButton(QelButton::Primary, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Primary", this));
+        disabledButtons.append(new QelButton(QelButton::Success, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Success", this));
+        disabledButtons.append(new QelButton(QelButton::Info, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Info", this));
+        disabledButtons.append(new QelButton(QelButton::Warning, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Warning", this));
+        disabledButtons.append(new QelButton(QelButton::Danger, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Danger", this));
+        for (QelButton *button : disabledButtons) {
+            button->setDisabled(true);
+        }
+        addButtonRow(mainLayout, "Disabled Buttons", disabledButtons);
+
+        QList<QelButton *> disabledPlainButtons;
+        disabledPlainButtons.append(new QelButton(QelButton::Default, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Default", this));
+        disabledPlainButtons.append(new QelButton(QelButton::Primary, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Primary", this));
+        disabledPlainButtons.append(new QelButton(QelButton::Success, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Success", this));
+        disabledPlainButtons.append(new QelButton(QelButton::Info, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Info", this));
+        disabledPlainButtons.append(new QelButton(QelButton::Warning, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Warning", this));
+        disabledPlainButtons.append(new QelButton(QelButton::Danger, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Danger", this));
+        for (QelButton *button : disabledPlainButtons) {
+            button->setDisabled(true);
+        }
+        addButtonRow(mainLayout, "Disabled Plain Buttons", disabledPlainButtons);
+
+        QList<QelButton *> textButtons;
+        textButtons.append(new QelButton(QelButton::Default, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Default Text", this));
+        textButtons.append(new QelButton(QelButton::Primary, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Primary Text", this));
+        textButtons.append(new QelButton(QelButton::Success, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Success Text", this));
+        for (QelButton *button : textButtons) {
+            button->setTextMode(true);
+            button->setBg(true);
+        }
+        addButtonRow(mainLayout, "Text Buttons", textButtons);
+
+        QList<QelButton *> linkButtons;
+        linkButtons.append(new QelButton(QelButton::Default, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Default Link", this));
+        linkButtons.append(new QelButton(QelButton::Primary, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Primary Link", this));
+        linkButtons.append(new QelButton(QelButton::Danger, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Danger Link", this));
+        for (QelButton *button : linkButtons) {
+            button->setLinkMode(true);
+        }
+        addButtonRow(mainLayout, "Link Buttons", linkButtons);
+
+        QList<QelButton *> customColorButtons;
+        QelButton *customTeal = new QelButton(QelButton::Primary, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Custom #13c2c2", this);
+        customTeal->setColor("#13c2c2");
+        QelButton *customPurple = new QelButton(QelButton::Primary, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Custom #722ed1", this);
+        customPurple->setColor("#722ed1");
+        customColorButtons.append(customTeal);
+        customColorButtons.append(customPurple);
+        addButtonRow(mainLayout, "Custom Color Buttons", customColorButtons);
+
+        QList<QelButton *> sizeButtons;
+        sizeButtons.append(new QelButton(QelButton::Primary, QelButton::Large, false, false, false, false, QelButton::Button, QIcon(), "Large", this));
+        sizeButtons.append(new QelButton(QelButton::Primary, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Medium", this));
+        sizeButtons.append(new QelButton(QelButton::Primary, QelButton::Small, false, false, false, false, QelButton::Button, QIcon(), "Small", this));
+        sizeButtons.append(new QelButton(QelButton::Primary, QelButton::Mini, false, false, false, false, QelButton::Button, QIcon(), "Mini", this));
+        addButtonRow(mainLayout, "Button Sizes", sizeButtons);
+
+        addElementPlusLinkTextShowcase(mainLayout);
+        addPopupAndAnimationDemo(mainLayout);
+        setLayout(mainLayout);
+    }
+
+private:
+    QWidget *animationTarget_ = nullptr;
+
+    void addButtonRow(QVBoxLayout *layout, const QString &title, const QList<QelButton *> &buttons)
+    {
+        QHBoxLayout *rowLayout = new QHBoxLayout();
+
+        QLabel *label = new QLabel(title);
+        rowLayout->addWidget(label);
+
+        for (QelButton *button : buttons) {
+            rowLayout->addWidget(button);
+        }
+
+        layout->addLayout(rowLayout);
+    }
+
+    void addElementPlusLinkTextShowcase(QVBoxLayout *layout)
+    {
         QLabel *linkTitle = new QLabel("Link Button", this);
-        linkTitle->setStyleSheet("font-size: 28px; font-weight: 700; color: #303133;");
-        mainLayout->addWidget(linkTitle);
+        linkTitle->setStyleSheet("font-size: 28px; font-weight: 700; color: #303133; margin-top: 8px;");
+        layout->addWidget(linkTitle);
 
-        QFrame *linkCard = createCard();
+        QFrame *linkCard = createElementCard();
         QVBoxLayout *linkLayout = new QVBoxLayout(linkCard);
-        linkLayout->addWidget(makeSectionLabel("Basic link button"));
+        linkLayout->setSpacing(10);
+        linkLayout->addWidget(createElementSectionLabel("Basic link button"));
 
-        QList<QelButton *> basicLinks = makeSemanticButtons(this);
+        QList<QelButton *> basicLinks = makeElementSemanticButtons(this);
         for (QelButton *button : basicLinks) {
             button->setLinkMode(true);
         }
-        linkLayout->addLayout(makeButtonRow(basicLinks));
+        linkLayout->addLayout(makeElementRow(basicLinks));
 
-        linkLayout->addWidget(makeSectionLabel("Disabled link button"));
-        QList<QelButton *> disabledLinks = makeSemanticButtons(this);
+        linkLayout->addWidget(createElementSectionLabel("Disabled link button"));
+        QList<QelButton *> disabledLinks = makeElementSemanticButtons(this);
         for (QelButton *button : disabledLinks) {
             button->setLinkMode(true);
             button->setDisabled(true);
         }
-        linkLayout->addLayout(makeButtonRow(disabledLinks));
-        mainLayout->addWidget(linkCard);
+        linkLayout->addLayout(makeElementRow(disabledLinks));
+        layout->addWidget(linkCard);
 
         QLabel *textTitle = new QLabel("Text Button", this);
-        textTitle->setStyleSheet("font-size: 28px; font-weight: 700; color: #303133;");
-        mainLayout->addWidget(textTitle);
+        textTitle->setStyleSheet("font-size: 28px; font-weight: 700; color: #303133; margin-top: 12px;");
+        layout->addWidget(textTitle);
 
         QLabel *textDesc = new QLabel("Buttons without border and background.", this);
         textDesc->setStyleSheet("font-size: 18px; color: #606266;");
-        mainLayout->addWidget(textDesc);
+        layout->addWidget(textDesc);
 
-        QFrame *textCard = createCard();
+        QFrame *textCard = createElementCard();
         QVBoxLayout *textLayout = new QVBoxLayout(textCard);
+        textLayout->setSpacing(10);
 
-        textLayout->addWidget(makeSectionLabel("Basic text button"));
-        QList<QelButton *> basicTexts = makeSemanticButtons(this);
+        textLayout->addWidget(createElementSectionLabel("Basic text button"));
+        QList<QelButton *> basicTexts = makeElementSemanticButtons(this);
         for (QelButton *button : basicTexts) {
             button->setTextMode(true);
         }
-        textLayout->addLayout(makeButtonRow(basicTexts));
+        textLayout->addLayout(makeElementRow(basicTexts));
 
-        textLayout->addWidget(makeSectionLabel("Background color always on"));
-        QList<QelButton *> bgTexts = makeSemanticButtons(this);
+        textLayout->addWidget(createElementSectionLabel("Background color always on"));
+        QList<QelButton *> bgTexts = makeElementSemanticButtons(this);
         for (QelButton *button : bgTexts) {
             button->setTextMode(true);
             button->setBg(true);
         }
-        textLayout->addLayout(makeButtonRow(bgTexts));
+        textLayout->addLayout(makeElementRow(bgTexts));
 
-        textLayout->addWidget(makeSectionLabel("Disabled text button"));
-        QList<QelButton *> disabledTexts = makeSemanticButtons(this);
+        textLayout->addWidget(createElementSectionLabel("Disabled text button"));
+        QList<QelButton *> disabledTexts = makeElementSemanticButtons(this);
         for (QelButton *button : disabledTexts) {
             button->setTextMode(true);
             button->setDisabled(true);
         }
-        textLayout->addLayout(makeButtonRow(disabledTexts));
+        textLayout->addLayout(makeElementRow(disabledTexts));
 
-        mainLayout->addWidget(textCard);
-        mainLayout->addStretch();
-        setLayout(mainLayout);
-        setStyleSheet("QWidget { background: #f5f7fa; }");
+        layout->addWidget(textCard);
     }
 
-private:
-    QFrame *createCard()
+    QFrame *createElementCard()
     {
         QFrame *card = new QFrame(this);
         card->setStyleSheet("QFrame { background: #ffffff; border: 1px solid #dcdfe6; border-radius: 4px; }");
         return card;
     }
 
-    QLabel *makeSectionLabel(const QString &text)
+    QLabel *createElementSectionLabel(const QString &text)
     {
         QLabel *label = new QLabel(text, this);
-        label->setStyleSheet("font-size: 16px; color: #303133; margin: 8px 0;");
+        label->setStyleSheet("font-size: 16px; color: #303133; margin: 4px 0;");
         return label;
     }
 
-    QList<QelButton *> makeSemanticButtons(QWidget *parent)
+    QList<QelButton *> makeElementSemanticButtons(QWidget *parent)
     {
         QList<QelButton *> buttons;
         buttons.append(new QelButton(QelButton::Default, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "plain", parent));
@@ -109,7 +229,7 @@ private:
         return buttons;
     }
 
-    QHBoxLayout *makeButtonRow(const QList<QelButton *> &buttons)
+    QHBoxLayout *makeElementRow(const QList<QelButton *> &buttons)
     {
         QHBoxLayout *row = new QHBoxLayout();
         row->setSpacing(12);
@@ -118,6 +238,71 @@ private:
         }
         row->addStretch();
         return row;
+    }
+
+    void addPopupAndAnimationDemo(QVBoxLayout *layout)
+    {
+        QLabel *title = new QLabel("Popup && Animation Demo");
+        layout->addWidget(title);
+
+        QHBoxLayout *demoRow = new QHBoxLayout();
+        QelButton *showPopupButton = new QelButton(QelButton::Primary, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Show Popup", this);
+        QelButton *fadeButton = new QelButton(QelButton::Success, QelButton::Medium, true, false, false, false, QelButton::Button, QIcon(), "Fade In/Out", this);
+        QelButton *pressEffectButton = new QelButton(QelButton::Warning, QelButton::Medium, false, true, false, false, QelButton::Button, QIcon(), "Press Feedback", this);
+
+        animationTarget_ = new QLabel("Animation Target", this);
+        animationTarget_->setMinimumWidth(140);
+        animationTarget_->setStyleSheet("QLabel{background:#f5f7fa;border:1px solid #dcdfe6;padding:6px;border-radius:4px;}");
+
+        demoRow->addWidget(showPopupButton);
+        demoRow->addWidget(fadeButton);
+        demoRow->addWidget(pressEffectButton);
+        demoRow->addWidget(animationTarget_);
+        demoRow->addStretch();
+        layout->addLayout(demoRow);
+
+        connect(showPopupButton, &QelButton::clicked, this, [this, showPopupButton]() {
+            QFrame *popup = new QFrame(nullptr, Qt::ToolTip);
+            popup->setAttribute(Qt::WA_DeleteOnClose, true);
+            popup->setStyleSheet("QFrame{background:#ffffff;border:1px solid #dcdfe6;border-radius:4px;} QLabel{padding:6px;color:#606266;}");
+
+            QVBoxLayout *popupLayout = new QVBoxLayout(popup);
+            popupLayout->setContentsMargins(8, 8, 8, 8);
+            popupLayout->addWidget(new QLabel("QelPopupManager demo", popup));
+            popupLayout->addWidget(new QLabel("- auto placement clamp", popup));
+            popupLayout->addWidget(new QLabel("- zIndex allocate", popup));
+
+            popup->resize(200, 90);
+
+            const QPoint pos = QelPopupManager::computePopupPosition(showPopupButton, popup->size(), PopupPlacement::Bottom);
+            popup->move(pos);
+            popup->raise();
+            popup->setWindowTitle(QString::number(QelPopupManager::acquireZIndex(PopupType::Popover)));
+            QelPopupManager::registerPopup(popup, {PopupType::Popover, true, true, false});
+            QelPopupManager::handleScreenBoundary(popup);
+
+            popup->show();
+            QelAnimationHelper::fadeIn(popup, 180);
+            QTimer::singleShot(1600, popup, [popup]() {
+                QelAnimationHelper::fadeOut(popup, 160);
+            });
+        });
+
+        connect(fadeButton, &QelButton::clicked, this, [this]() {
+            if (animationTarget_ == nullptr) {
+                return;
+            }
+
+            if (animationTarget_->isVisible()) {
+                QelAnimationHelper::fadeOut(animationTarget_, 140);
+            } else {
+                QelAnimationHelper::fadeIn(animationTarget_, 160);
+            }
+        });
+
+        connect(pressEffectButton, &QelButton::clicked, this, [pressEffectButton]() {
+            QelAnimationHelper::pressFeedback(pressEffectButton, 110);
+        });
     }
 };
 

--- a/QelButton/QelButtonTester.h
+++ b/QelButton/QelButtonTester.h
@@ -82,6 +82,41 @@ public:
         }
         addButtonRow(mainLayout, "Disabled Plain Buttons", disabledPlainButtons);
 
+        QList<QelButton *> textButtons;
+        textButtons.append(new QelButton(QelButton::Default, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Default Text", this));
+        textButtons.append(new QelButton(QelButton::Primary, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Primary Text", this));
+        textButtons.append(new QelButton(QelButton::Success, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Success Text", this));
+        for (QelButton *button : textButtons) {
+            button->setTextMode(true);
+            button->setBg(true);
+        }
+        addButtonRow(mainLayout, "Text Buttons", textButtons);
+
+        QList<QelButton *> linkButtons;
+        linkButtons.append(new QelButton(QelButton::Default, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Default Link", this));
+        linkButtons.append(new QelButton(QelButton::Primary, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Primary Link", this));
+        linkButtons.append(new QelButton(QelButton::Danger, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Danger Link", this));
+        for (QelButton *button : linkButtons) {
+            button->setLinkMode(true);
+        }
+        addButtonRow(mainLayout, "Link Buttons", linkButtons);
+
+        QList<QelButton *> customColorButtons;
+        QelButton *customTeal = new QelButton(QelButton::Primary, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Custom #13c2c2", this);
+        customTeal->setColor("#13c2c2");
+        QelButton *customPurple = new QelButton(QelButton::Primary, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Custom #722ed1", this);
+        customPurple->setColor("#722ed1");
+        customColorButtons.append(customTeal);
+        customColorButtons.append(customPurple);
+        addButtonRow(mainLayout, "Custom Color Buttons", customColorButtons);
+
+        QList<QelButton *> sizeButtons;
+        sizeButtons.append(new QelButton(QelButton::Primary, QelButton::Large, false, false, false, false, QelButton::Button, QIcon(), "Large", this));
+        sizeButtons.append(new QelButton(QelButton::Primary, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Medium", this));
+        sizeButtons.append(new QelButton(QelButton::Primary, QelButton::Small, false, false, false, false, QelButton::Button, QIcon(), "Small", this));
+        sizeButtons.append(new QelButton(QelButton::Primary, QelButton::Mini, false, false, false, false, QelButton::Button, QIcon(), "Mini", this));
+        addButtonRow(mainLayout, "Button Sizes", sizeButtons);
+
         addPopupAndAnimationDemo(mainLayout);
         setLayout(mainLayout);
     }

--- a/QelCommon/QelControlTypes.h
+++ b/QelCommon/QelControlTypes.h
@@ -5,9 +5,8 @@ namespace qel {
 
 enum class QelControlSize {
     Large,
-    Medium,
-    Small,
-    Mini
+    Default,
+    Small
 };
 
 // Semantic color type shared by multiple controls (not Button-specific).

--- a/QelCommon/QelControlTypes.h
+++ b/QelCommon/QelControlTypes.h
@@ -10,15 +10,23 @@ enum class QelControlSize {
     Mini
 };
 
-enum class QelButtonType {
+// Semantic color type shared by multiple controls (not Button-specific).
+enum class QelSemanticType {
     Default,
     Primary,
     Success,
     Warning,
     Danger,
-    Info,
-    Text
+    Info
 };
+
+enum class QelButtonVisualType {
+    Filled,
+    Text,
+    Link
+};
+
+using QelButtonType = QelSemanticType;
 
 enum class QelNativeButtonType {
     Button,

--- a/QelCommon/QelControlTypes.h
+++ b/QelCommon/QelControlTypes.h
@@ -1,0 +1,31 @@
+#ifndef QELCONTROLTYPES_H
+#define QELCONTROLTYPES_H
+
+namespace qel {
+
+enum class QelControlSize {
+    Large,
+    Medium,
+    Small,
+    Mini
+};
+
+enum class QelButtonType {
+    Default,
+    Primary,
+    Success,
+    Warning,
+    Danger,
+    Info,
+    Text
+};
+
+enum class QelNativeButtonType {
+    Button,
+    Submit,
+    Reset
+};
+
+} // namespace qel
+
+#endif // QELCONTROLTYPES_H

--- a/QelStyleHelper/QelStyleHelper.cpp
+++ b/QelStyleHelper/QelStyleHelper.cpp
@@ -27,9 +27,9 @@ QelVisualState QelStyleHelper::resolveState(const QelStateContext &ctx)
     return QelVisualState::Normal;
 }
 
-QelStyleHelper::ButtonStyle QelStyleHelper::buttonStyle(QelTheme::ButtonKind kind,
-                                                        bool isPlain,
-                                                        QelVisualState state)
+QelStyleHelper::ComponentStyle QelStyleHelper::buttonStyle(QelTheme::ButtonKind kind,
+                                                           bool isPlain,
+                                                           QelVisualState state)
 {
     const QelTheme::ButtonColors colors = QelTheme::buttonColors(kind, isPlain);
 
@@ -46,6 +46,70 @@ QelStyleHelper::ButtonStyle QelStyleHelper::buttonStyle(QelTheme::ButtonKind kin
     default:
         return {colors.normal.background, colors.normal.text, colors.normal.border};
     }
+}
+
+QelStyleHelper::StateStyleSet QelStyleHelper::buttonStateStyles(QelTheme::ButtonKind kind, bool isPlain)
+{
+    return {
+        buttonStyle(kind, isPlain, QelVisualState::Normal),
+        buttonStyle(kind, isPlain, QelVisualState::Hover),
+        buttonStyle(kind, isPlain, QelVisualState::Active),
+        buttonStyle(kind, isPlain, QelVisualState::Focus),
+        buttonStyle(kind, isPlain, QelVisualState::Disabled),
+        buttonStyle(kind, isPlain, QelVisualState::Loading)
+    };
+}
+
+QString QelStyleHelper::composeStateStyleSheet(const QString &baseSelector,
+                                               const QString &loadingSelector,
+                                               const StateStyleSet &styles,
+                                               bool disableFocusOutline)
+{
+    QString style;
+    style += QString("%1 { background-color: %2; color: %3; border: 1px solid %4;")
+                 .arg(baseSelector)
+                 .arg(styles.normal.background)
+                 .arg(styles.normal.text)
+                 .arg(styles.normal.border);
+
+    style += QString("%1:hover { background-color: %2; color: %3; border: 1px solid %4; }")
+                 .arg(baseSelector)
+                 .arg(styles.hover.background)
+                 .arg(styles.hover.text)
+                 .arg(styles.hover.border);
+
+    style += QString("%1:pressed { background-color: %2; color: %3; border: 1px solid %4; }")
+                 .arg(baseSelector)
+                 .arg(styles.active.background)
+                 .arg(styles.active.text)
+                 .arg(styles.active.border);
+
+    style += QString("%1:focus { background-color: %2; color: %3; border: 1px solid %4;%5 }")
+                 .arg(baseSelector)
+                 .arg(styles.focus.background)
+                 .arg(styles.focus.text)
+                 .arg(styles.focus.border)
+                 .arg(disableFocusOutline ? " outline: none;" : "");
+
+    style += QString("%1:disabled { background-color: %2; color: %3; border: 1px solid %4; }")
+                 .arg(baseSelector)
+                 .arg(styles.disabled.background)
+                 .arg(styles.disabled.text)
+                 .arg(styles.disabled.border);
+
+    style += QString("%1 { background-color: %2; color: %3; border: 1px solid %4; }")
+                 .arg(loadingSelector)
+                 .arg(styles.loading.background)
+                 .arg(styles.loading.text)
+                 .arg(styles.loading.border);
+
+    return style;
+}
+
+QString QelStyleHelper::buttonStateStyleSheet(QelTheme::ButtonKind kind, bool isPlain)
+{
+    const StateStyleSet styles = buttonStateStyles(kind, isPlain);
+    return composeStateStyleSheet("QPushButton", "QPushButton[qel-loading=\"true\"]", styles, true);
 }
 
 } // namespace qel

--- a/QelStyleHelper/QelStyleHelper.cpp
+++ b/QelStyleHelper/QelStyleHelper.cpp
@@ -66,7 +66,7 @@ QString QelStyleHelper::composeStateStyleSheet(const QString &baseSelector,
                                                bool disableFocusOutline)
 {
     QString style;
-    style += QString("%1 { background-color: %2; color: %3; border: 1px solid %4;")
+    style += QString("%1 { background-color: %2; color: %3; border: 1px solid %4; }")
                  .arg(baseSelector)
                  .arg(styles.normal.background)
                  .arg(styles.normal.text)

--- a/QelStyleHelper/QelStyleHelper.h
+++ b/QelStyleHelper/QelStyleHelper.h
@@ -26,14 +26,31 @@ struct QelStateContext {
 
 class QelStyleHelper {
 public:
-    struct ButtonStyle {
+    struct ComponentStyle {
         QString background;
         QString text;
         QString border;
     };
 
+    struct StateStyleSet {
+        ComponentStyle normal;
+        ComponentStyle hover;
+        ComponentStyle active;
+        ComponentStyle focus;
+        ComponentStyle disabled;
+        ComponentStyle loading;
+    };
+
     static QelVisualState resolveState(const QelStateContext &ctx);
-    static ButtonStyle buttonStyle(QelTheme::ButtonKind kind, bool isPlain, QelVisualState state);
+    static ComponentStyle buttonStyle(QelTheme::ButtonKind kind, bool isPlain, QelVisualState state);
+    static StateStyleSet buttonStateStyles(QelTheme::ButtonKind kind, bool isPlain);
+
+    static QString composeStateStyleSheet(const QString &baseSelector,
+                                          const QString &loadingSelector,
+                                          const StateStyleSet &styles,
+                                          bool disableFocusOutline = false);
+
+    static QString buttonStateStyleSheet(QelTheme::ButtonKind kind, bool isPlain);
 };
 
 } // namespace qel

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ QelIcon *icon = new QelIcon(QelIcon::Search, 16, this);
 ```cpp
 #include "QelButton.h"
 
-QelButton *button = new QelButton(QelButton::Primary, QelButton::Medium, false, false, false, false, QelButton::Button, QIcon(), "Primary Button", this);
+QelButton *button = new QelButton(QelButton::Primary, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Primary Button", this);
 ```
 
 ### QelNumberInput 示例

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ QelIcon *icon = new QelIcon(QelIcon::Search, 16, this);
 ```cpp
 #include "QelButton.h"
 
-QelButton *button = new QelButton(QelButton::Primary, QelButton::Default, false, false, false, false, QelButton::Button, QIcon(), "Primary Button", this);
+QelButton *button = new QelButton(QelButton::Primary, QelButton::DefaultSize, false, false, false, false, QelButton::Button, QIcon(), "Primary Button", this);
 ```
 
 ### QelNumberInput 示例


### PR DESCRIPTION
### Motivation
- Prevent `QelStyleHelper` from becoming a collection of per-component state-sheet functions by providing a reusable composer for common visual states.
- Let `QelTheme` remain the single source of token ownership while `QelStyleHelper` offers generic primitives to derive QSS for any component.
- Avoid forcing each new component to add a bespoke `*StateStyleSheet` function; components should only map theme tokens into a reusable state set.

### Description
- Replace `ButtonStyle` with a generic `ComponentStyle` and add `StateStyleSet` to represent the six common visual states (`normal`, `hover`, `active`, `focus`, `disabled`, `loading`).
- Add `composeStateStyleSheet(const QString &baseSelector, const QString &loadingSelector, const StateStyleSet &styles, bool disableFocusOutline)` to generate standard state QSS for arbitrary component selectors.
- Add `buttonStateStyles(...)` to map button theme tokens into a `StateStyleSet` and keep `buttonStateStyleSheet(...)` as a thin wrapper that calls the generic composer for backward compatibility.
- Update `QelButton::updateButtonStyle()` to use `QelStyleHelper::buttonStateStyleSheet(...)` for state QSS while retaining geometry/size/border-radius logic inside the component.

### Testing
- Attempted to build the button target with `qmake QelButton/QelButton.pro -o /tmp/QelButton.Makefile && make -f /tmp/QelButton.Makefile -j2` and the command failed because `qmake` is not installed in the environment (`command not found`).
- Performed local code inspection to verify that `QelButton` now delegates state stylesheet composition to the helper and that the helper provides the generic composer; no runtime artifacts were produced due to the missing `qmake` tool.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d9701fba083279921eeb8460492f4)